### PR TITLE
既存UIコンポーネントの移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "generate:component": "hygen new fc"
   },
   "dependencies": {
+    "@heroicons/react": "^2.0.18",
     "clsx": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/atoms/Avatar/Avatar.stories.tsx
+++ b/src/components/atoms/Avatar/Avatar.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Avatar } from "./Avatar";
+
+export default {
+  component: Avatar,
+  parameters: {
+    controls: { expanded: true },
+  },
+} satisfies Meta<typeof Avatar>;
+
+export const Default: StoryObj<typeof Avatar> = {
+  argTypes: {
+    onClick: { action: "clicked" },
+  },
+  args: {
+    src: "",
+  },
+};

--- a/src/components/atoms/Avatar/Avatar.tsx
+++ b/src/components/atoms/Avatar/Avatar.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { UserCircleIcon } from "@heroicons/react/24/solid";
+import type { AvatarProps } from "./type";
+
+export const Avatar = ({ src, onClick }: AvatarProps) => {
+  const [isError, setIsError] = useState(false);
+
+  return (
+    <button
+      onClick={onClick}
+      className="h-8 w-8"
+      type="button"
+    >
+      {!src || isError ? (
+        <UserCircleIcon className="aspect-square rounded-full text-gray ring-4 ring-inset ring-gray" />
+      ) : (
+        <img
+          src={src}
+          alt="avatar"
+          width={32}
+          height={32}
+          className="aspect-square rounded-full object-cover"
+          onLoad={() => {
+            setIsError(false);
+          }}
+          onError={() => {
+            setIsError(true);
+          }}
+          key={src}
+        />
+      )}
+    </button>
+  );
+};

--- a/src/components/atoms/Avatar/index.ts
+++ b/src/components/atoms/Avatar/index.ts
@@ -1,0 +1,1 @@
+export * from './Avatar';

--- a/src/components/atoms/Avatar/type.ts
+++ b/src/components/atoms/Avatar/type.ts
@@ -1,0 +1,3 @@
+export type AvatarProps = Pick<React.ImgHTMLAttributes<HTMLImageElement>, "src"> & {
+  onClick?: () => void;
+};

--- a/src/components/atoms/Badge/Badge.stories.tsx
+++ b/src/components/atoms/Badge/Badge.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Badge } from "./Badge";
+import { COLORS, THEMES } from "./const";
+
+export default {
+  component: Badge,
+  parameters: {
+    controls: { expanded: true },
+    layout: "centered",
+  },
+} satisfies Meta<typeof Badge>;
+
+export const Default: StoryObj<typeof Badge> = {
+  argTypes: {
+    color: {
+      options: COLORS,
+      control: { type: "select" },
+    },
+    theme: {
+      options: THEMES,
+      control: { type: "select" },
+    },
+  },
+  args: {
+    children: "HELLO",
+    color: "primary",
+    theme: "border",
+  },
+};
+
+const allBadges = COLORS.map((color) => (
+  <div
+    key={color}
+    className="flex flex-col gap-y-6"
+  >
+    {THEMES.map((theme) => (
+      <Badge
+        key={`${color}-${theme}`}
+        theme={theme}
+        color={color}
+      >
+        {/* Capitalizing first letter */}
+        {color.charAt(0).toUpperCase() + color.slice(1)}
+      </Badge>
+    ))}
+  </div>
+));
+
+export const All = () => {
+  return <div className="flex gap-x-9">{allBadges}</div>;
+};

--- a/src/components/atoms/Badge/Badge.tsx
+++ b/src/components/atoms/Badge/Badge.tsx
@@ -1,0 +1,6 @@
+import { BADGE_CLASS_NAME } from "./const";
+import type { BadgeProps } from "./type";
+
+export const Badge = ({ children, color = "primary", theme = "fill" }: BadgeProps) => {
+  return <span className={BADGE_CLASS_NAME({ color, theme })}>{children}</span>;
+};

--- a/src/components/atoms/Badge/const.ts
+++ b/src/components/atoms/Badge/const.ts
@@ -1,0 +1,165 @@
+import { tv } from "tailwind-variants";
+
+export const COLORS = [
+  "primary",
+  "blue",
+  "green",
+  "yellow",
+  "red",
+  "black",
+  "gray",
+  "lightGray",
+] as const;
+
+export const THEMES = ["fill", "border", "light-fill"] as const;
+
+export const BADGE_CLASS_NAME = tv({
+  base: "rounded-full px-2 py-1 text-[10px]",
+  variants: {
+    color: {
+      primary: "",
+      blue: "",
+      black: "",
+      green: "",
+      yellow: "",
+      red: "",
+      gray: "",
+      lightGray: "",
+    },
+    theme: {
+      border: "",
+      fill: "",
+      "light-fill": "",
+    },
+  },
+  compoundVariants: [
+    // Primary
+    {
+      color: "primary",
+      theme: "fill",
+      class: "bg-primary-600 text-white",
+    },
+    {
+      color: "primary",
+      theme: "border",
+      class: "border-primary-600 text-primary-600 border bg-white",
+    },
+    {
+      color: "primary",
+      theme: "light-fill",
+      class: "bg-primary-50 text-primary-600",
+    },
+    // -- Blue --
+    {
+      color: "blue",
+      theme: "fill",
+      class: "bg-blue text-white",
+    },
+    {
+      color: "blue",
+      theme: "border",
+      class: "border-blue text-blue border bg-white",
+    },
+    {
+      color: "blue",
+      theme: "light-fill",
+      class: "bg-blue-light text-blue",
+    },
+    // -- Green --
+    {
+      color: "green",
+      theme: "fill",
+      class: "bg-green text-white",
+    },
+    {
+      color: "green",
+      theme: "border",
+      class: "border-green text-green-dark border bg-white",
+    },
+    {
+      color: "green",
+      theme: "light-fill",
+      class: "bg-green-light text-green-dark",
+    },
+    // -- Yellow --
+    {
+      color: "yellow",
+      theme: "fill",
+      class: "bg-yellow text-black",
+    },
+    {
+      color: "yellow",
+      theme: "border",
+      class: "border-yellow  text-yellow-dark border bg-white",
+    },
+    {
+      color: "yellow",
+      theme: "light-fill",
+      class: "bg-yellow-light text-yellow-dark",
+    },
+    // -- Red --
+    {
+      color: "red",
+      theme: "fill",
+      class: "bg-red text-white",
+    },
+    {
+      color: "red",
+      theme: "border",
+      class: "border-red text-red border bg-white",
+    },
+    {
+      color: "red",
+      theme: "light-fill",
+      class: "bg-red-light text-red",
+    },
+    // -- Black --
+    {
+      color: "black",
+      theme: "fill",
+      class: "bg-black text-white",
+    },
+    {
+      color: "black",
+      theme: "border",
+      class: "border border-black bg-white text-black",
+    },
+    {
+      color: "black",
+      theme: "light-fill",
+      class: "bg-gray-extraLight text-black",
+    },
+    // -- Gray --
+    {
+      color: "gray",
+      theme: "fill",
+      class: "bg-gray-dark text-white",
+    },
+    {
+      color: "gray",
+      theme: "border",
+      class: "border-gray-dark text-gray-dark border bg-white",
+    },
+    {
+      color: "gray",
+      theme: "light-fill",
+      class: "bg-gray-extraLight text-gray-dark",
+    },
+    // -- Light Gray --
+    {
+      color: "lightGray",
+      theme: "fill",
+      class: "bg-gray text-white",
+    },
+    {
+      color: "lightGray",
+      theme: "border",
+      class: "border-gray border bg-white text-black",
+    },
+    {
+      color: "lightGray",
+      theme: "light-fill",
+      class: "bg-gray-extraLight text-black",
+    },
+  ],
+});

--- a/src/components/atoms/Badge/index.ts
+++ b/src/components/atoms/Badge/index.ts
@@ -1,0 +1,1 @@
+export * from "./Badge";

--- a/src/components/atoms/Badge/type.ts
+++ b/src/components/atoms/Badge/type.ts
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+import { COLORS, THEMES } from "./const";
+
+export type Colors = (typeof COLORS)[number];
+
+export type Theme = (typeof THEMES)[number];
+
+export type BadgeProps = {
+  children: ReactNode;
+  color?: Colors;
+  theme?: Theme;
+};

--- a/src/components/atoms/Button/Button.stories.tsx
+++ b/src/components/atoms/Button/Button.stories.tsx
@@ -1,13 +1,101 @@
+import { PlusIcon } from "@heroicons/react/24/outline";
 import { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./Button";
+import { ButtonProps } from "./type";
+
+const ButtonSet = ({
+  children,
+  ...props
+}: Pick<ButtonProps, "theme" | "disabled" | "loading" | "size" | "children">) => {
+  return (
+    <div className="flex gap-2">
+      <Button {...props}>{children}</Button>
+      <Button
+        {...props}
+        icon={<PlusIcon />}
+        iconPosition="left"
+      >
+        {children}
+      </Button>
+      <Button
+        {...props}
+        icon={<PlusIcon />}
+        iconPosition="right"
+      >
+        {children}
+      </Button>
+      <Button
+        {...props}
+        icon={<PlusIcon />}
+        iconPosition="right"
+      />
+    </div>
+  );
+};
+
+const ButtonSetSection = ({
+  title,
+  ...props
+}: Pick<ButtonProps, "theme" | "size" | "children"> & { title: string }) => (
+  <section>
+    <h2 className="mb-2">{title}</h2>
+    <div className="flex flex-col gap-2">
+      <ButtonSet {...props} />
+      <ButtonSet
+        {...props}
+        disabled
+      />
+      <ButtonSet
+        {...props}
+        loading
+      />
+      <ButtonSet
+        {...props}
+        disabled
+        loading
+      />
+    </div>
+  </section>
+);
+
+const ThemeTemplate = (props: Pick<ButtonProps, "children" | "theme" | "onClick">) => {
+  return (
+    <article className="flex flex-col gap-4">
+      <ButtonSetSection
+        title="Small"
+        size="small"
+        {...props}
+      />
+      <ButtonSetSection
+        title="Medium"
+        size="medium"
+        {...props}
+      />
+      <ButtonSetSection
+        title="Large"
+        size="large"
+        {...props}
+      />
+    </article>
+  );
+};
 
 export default {
   component: Button,
 } satisfies Meta<typeof Button>;
 
 export const Default: StoryObj<typeof Button> = {
-  argTypes: {},
+  argTypes: {
+    onClick: { action: "clicked" },
+  },
   args: {
     children: "ボタン",
+    theme: "primary",
+    size: "small",
   },
 };
+
+export const Primary = () => <ThemeTemplate theme="primary">ボタン</ThemeTemplate>;
+export const Red = () => <ThemeTemplate theme="red">ボタン</ThemeTemplate>;
+export const White = () => <ThemeTemplate theme="white">ボタン</ThemeTemplate>;
+export const NoBackground = () => <ThemeTemplate theme="no-background">ボタン</ThemeTemplate>;

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -1,8 +1,54 @@
-import clsx from "clsx";
-import { ButtonProp } from "./type";
+import { Spinner } from "../Spinner";
+import { BUTTON_CHILDREN_CLASS_NAME, BUTTON_CLASS_NAME, BUTTON_ICON_CLASS_NAME } from "./const";
+import { ButtonProps } from "./type";
 
-export const Button = ({ children }: ButtonProp) => (
-  <button className={clsx("rounded-full bg-black px-4 py-2 font-bold text-white")}>
-    {children}
-  </button>
-);
+export const Button = ({
+  children,
+  onClick,
+  icon,
+  size,
+  theme,
+  iconPosition = "left",
+  disabled = false,
+  loading = false,
+}: ButtonProps) => {
+  const showIcon = !loading && !!icon;
+  const spinnerProps = {
+    // NOTE: ボタンのサイズが`large`でテキストがない場合はアイコンを大きく表示するため
+    size: size === "large" && children ? "medium" : size,
+    theme: ["red", "primary"].includes(theme) ? "white" : "primary",
+  } as const;
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={BUTTON_CLASS_NAME({ theme, isLoading: loading, hasChildren: !!children, size })}
+    >
+      {showIcon && iconPosition === "left" && (
+        <span className={BUTTON_ICON_CLASS_NAME({ hasChildren: !!children, size, theme })}>
+          {icon}
+        </span>
+      )}
+      <Spinner
+        loading={loading}
+        {...spinnerProps}
+      />
+      {children && (
+        <span
+          className={BUTTON_CHILDREN_CLASS_NAME({
+            size,
+            theme,
+          })}
+        >
+          {loading ? "読み込み中..." : children}
+        </span>
+      )}
+      {showIcon && iconPosition === "right" && (
+        <span className={BUTTON_ICON_CLASS_NAME({ hasChildren: !!children, size, theme })}>
+          {icon}
+        </span>
+      )}
+    </button>
+  );
+};

--- a/src/components/atoms/Button/const.ts
+++ b/src/components/atoms/Button/const.ts
@@ -1,0 +1,98 @@
+import clsx from "clsx";
+import { tv } from "tailwind-variants";
+
+export const BUTTON_CLASS_NAME = tv({
+  base: clsx(
+    "inline-flex items-center justify-center gap-1 rounded outline-none duration-300 ease-out",
+    "disabled:opacity-20",
+    "focus-visible:ring-1 focus-visible:ring-primary-600 focus-visible:ring-offset-2",
+  ),
+  variants: {
+    isLoading: {
+      true: "",
+      false: "",
+    },
+    hasChildren: {
+      true: "text-center font-medium leading-none",
+      false: "",
+    },
+    theme: {
+      white:
+        "bg-white hover:bg-primary-100 border border-primary-400 shadow-01 active:bg-primary-300",
+      primary: "bg-primary-600 hover:bg-primary-700 shadow-01 active:bg-primary-900",
+      "no-background": "hover:bg-gray-extraLight",
+      red: "bg-red hover:bg-red-dark shadow-01",
+    },
+    size: {
+      small: "p-1.5",
+      medium: "p-2",
+      large: "p-2",
+    },
+  },
+  compoundVariants: [
+    {
+      theme: "white",
+      isLoading: true,
+      class: "text-black",
+    },
+    {
+      hasChildren: true,
+      size: "small",
+      class: "px-2 py-1.5",
+    },
+    {
+      hasChildren: true,
+      size: "large",
+      class: "px-4 py-3",
+    },
+    {
+      theme: "no-background",
+      class: "py-0.5 px-1",
+    },
+  ],
+});
+
+export const BUTTON_ICON_CLASS_NAME = tv({
+  base: "",
+  variants: {
+    theme: {
+      white: "text-primary-600",
+      primary: "text-gray-light",
+      "no-background": "text-primary-600",
+      red: "text-gray-light",
+    },
+    size: {
+      small: "w-3 h-3",
+      medium: "w-4 h-4",
+      large: "w-6 h-6",
+    },
+    hasChildren: {
+      true: "",
+      false: "",
+    },
+  },
+  compoundVariants: [
+    {
+      size: "large",
+      hasChildren: true,
+      class: "w-4 h-4",
+    },
+  ],
+});
+
+export const BUTTON_CHILDREN_CLASS_NAME = tv({
+  base: "",
+  variants: {
+    theme: {
+      white: "text-primary-600",
+      primary: "text-white",
+      "no-background": "text-primary-600 active:text-primary-900",
+      red: "text-white",
+    },
+    size: {
+      small: "text-xs",
+      medium: "text-sm",
+      large: "text-base",
+    },
+  },
+});

--- a/src/components/atoms/Button/type.ts
+++ b/src/components/atoms/Button/type.ts
@@ -1,3 +1,12 @@
-export type ButtonProp = {
-  children: React.ReactNode;
+import { ComponentProps, ReactNode } from "react";
+
+type Theme = "white" | "primary" | "red" | "no-background";
+type Size = "small" | "medium" | "large";
+
+export type ButtonProps = Pick<ComponentProps<"button">, "onClick" | "disabled" | "children"> & {
+  icon?: ReactNode;
+  theme: Theme;
+  size: Size;
+  loading?: boolean;
+  iconPosition?: "left" | "right";
 };

--- a/src/components/atoms/Checkbox/Checkbox.stories.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,70 @@
+import { ChangeEvent, ComponentProps, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Checkbox } from "./Checkbox";
+
+export default {
+  component: Checkbox,
+  parameters: {
+    controls: { expanded: true },
+  },
+  argTypes: {
+    onChange: {
+      action: "change",
+    },
+    children: {
+      type: "string",
+    },
+    value: {
+      type: "string",
+    },
+    checked: {
+      type: "boolean",
+    },
+  },
+} satisfies Meta<typeof Checkbox>;
+
+export const Default: StoryObj<typeof Checkbox> = {};
+
+export const Unchecked: StoryObj<typeof Checkbox> = {
+  args: {
+    checked: false,
+  },
+};
+
+export const Checked: StoryObj<typeof Checkbox> = {
+  args: {
+    checked: true,
+  },
+};
+
+export const WithLabel: StoryObj<typeof Checkbox> = {
+  args: {
+    children: "Text",
+  },
+};
+
+export const Controlled = ({
+  children,
+  value,
+  onChange,
+  checked,
+}: ComponentProps<typeof Checkbox>) => {
+  // Actual Use case
+  const [isChecked, setIsChecked] = useState(checked);
+
+  function handleOnChange(e: ChangeEvent<HTMLInputElement>) {
+    onChange?.(e);
+    setIsChecked((prev) => !prev);
+  }
+
+  return (
+    <Checkbox
+      value={value}
+      checked={isChecked}
+      onChange={handleOnChange}
+    >
+      {children}
+    </Checkbox>
+  );
+};

--- a/src/components/atoms/Checkbox/Checkbox.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.tsx
@@ -1,0 +1,24 @@
+import { CheckIcon } from "@heroicons/react/24/outline";
+import type { CheckboxProps } from "./type";
+
+export const Checkbox = ({ checked, children, value, onChange }: CheckboxProps) => {
+  return (
+    <label className="relative inline-flex cursor-pointer items-center gap-x-2">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        className={
+          "peer h-4 w-4 cursor-pointer appearance-none rounded-e rounded-s border border-gray-light checked:border-primary-600 checked:bg-primary-50"
+        }
+        value={value}
+      />
+      <CheckIcon
+        width={12}
+        height={12}
+        className={"absolute left-0.5 hidden text-primary-600 peer-checked:inline-block"}
+      />
+      <span className="font-noto-sans-cjk-jp text-s">{children}</span>
+    </label>
+  );
+};

--- a/src/components/atoms/Checkbox/index.ts
+++ b/src/components/atoms/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export * from "./Checkbox";

--- a/src/components/atoms/Checkbox/type.ts
+++ b/src/components/atoms/Checkbox/type.ts
@@ -1,0 +1,8 @@
+import { ReactNode, ComponentProps } from "react";
+
+export type CheckboxProps = {
+  checked: boolean;
+  children?: ReactNode;
+  value: string;
+  onChange: ComponentProps<"input">["onChange"];
+};

--- a/src/components/atoms/Input/InputNumber/InputNumber.stories.tsx
+++ b/src/components/atoms/Input/InputNumber/InputNumber.stories.tsx
@@ -1,0 +1,72 @@
+import { action } from "@storybook/addon-actions";
+import type { Meta, StoryObj } from "@storybook/react";
+import { InputNumber } from "./InputNumber";
+
+export default {
+  component: InputNumber,
+  args: {
+    id: "ID",
+    name: "name",
+    min: 0,
+    max: 100,
+    autoComplete: "off",
+    placeholder: "プレースホルダー",
+    disabled: false,
+    state: undefined,
+    showSuccess: false,
+    onChange: action("onChange"),
+    onFocus: action("onFocus"),
+    onBlur: action("onBlur"),
+  },
+  argTypes: {
+    state: {
+      control: {
+        type: "select",
+      },
+      options: ["error", undefined],
+    },
+    onChange: { action: "onChange" },
+  },
+  parameters: {
+    controls: { expanded: true },
+  },
+} satisfies Meta<typeof InputNumber>;
+
+export const Default: StoryObj<typeof InputNumber> = {
+  name: "未入力時",
+  args: {
+    defaultValue: 0,
+  },
+};
+
+export const Input: StoryObj<typeof InputNumber> = {
+  name: "入力時",
+  argTypes: {},
+  args: {
+    defaultValue: 10,
+  },
+};
+
+export const Error: StoryObj<typeof InputNumber> = {
+  name: "エラー時",
+  args: {
+    ...Input.args,
+    state: "error",
+  },
+};
+
+export const ShowSuccess: StoryObj<typeof InputNumber> = {
+  name: "成功表示あり",
+  args: {
+    ...Input.args,
+    state: undefined,
+    showSuccess: true,
+  },
+};
+
+export const Disabled: StoryObj<typeof InputNumber> = {
+  name: "入力不可",
+  args: {
+    disabled: true,
+  },
+};

--- a/src/components/atoms/Input/InputNumber/InputNumber.tsx
+++ b/src/components/atoms/Input/InputNumber/InputNumber.tsx
@@ -1,0 +1,23 @@
+import { CheckCircleIcon, ExclamationCircleIcon } from "@heroicons/react/24/outline";
+
+import { INPUT_CONTAINER_CLASS_NAME, INPUT_ICON_CLASS_NAME } from "../const";
+import type { InputNumberProps } from "./type";
+
+export const InputNumber = ({ state, showSuccess = false, ...props }: InputNumberProps) => {
+  const isSuccess = state !== "error" && showSuccess;
+
+  return (
+    <div className="relative">
+      <input
+        type="number"
+        className={INPUT_CONTAINER_CLASS_NAME({ isError: state === "error", isSuccess })}
+        {...props}
+      />
+
+      {state === "error" && (
+        <ExclamationCircleIcon className={INPUT_ICON_CLASS_NAME({ isError: true })} />
+      )}
+      {isSuccess && <CheckCircleIcon className={INPUT_ICON_CLASS_NAME({ isSuccess: true })} />}
+    </div>
+  );
+};

--- a/src/components/atoms/Input/InputNumber/index.ts
+++ b/src/components/atoms/Input/InputNumber/index.ts
@@ -1,0 +1,1 @@
+export * from './InputNumber';

--- a/src/components/atoms/Input/InputNumber/type.ts
+++ b/src/components/atoms/Input/InputNumber/type.ts
@@ -1,0 +1,21 @@
+import { ComponentProps } from "react";
+import { InputStyleProps } from "../type";
+
+export type InputNumberProps = InputStyleProps &
+  Pick<
+    ComponentProps<"input">,
+    | "id"
+    | "name"
+    | "min"
+    | "max"
+    | "placeholder"
+    | "disabled"
+    | "onFocus"
+    | "onBlur"
+    | "inputMode"
+    | "autoComplete"
+    | "onChange"
+    | "defaultValue"
+  > & {
+    showSuccess?: boolean;
+  };

--- a/src/components/atoms/Input/InputText/InputText.stories.tsx
+++ b/src/components/atoms/Input/InputText/InputText.stories.tsx
@@ -1,0 +1,83 @@
+import { action } from "@storybook/addon-actions";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { InputText } from "./InputText";
+
+export default {
+  component: InputText,
+  args: {
+    name: "name",
+    type: "text",
+    maxLength: undefined,
+    autoComplete: "off",
+    placeholder: "プレースホルダー",
+    disabled: false,
+    state: undefined,
+    showSuccess: false,
+    onChange: action("onChange"),
+    onFocus: action("onFocus"),
+    onBlur: action("onBlur"),
+  },
+  argTypes: {
+    type: {
+      control: {
+        type: "select",
+      },
+      options: ["email", "password", "search", "text"],
+      defaultValue: "text",
+    },
+    state: {
+      control: {
+        type: "select",
+      },
+      options: ["error", undefined],
+    },
+    onChange: { action: "onChange" },
+  },
+  parameters: {
+    controls: { expanded: true },
+  },
+} satisfies Meta<typeof InputText>;
+
+export const Default: StoryObj<typeof InputText> = {
+  name: "未入力時",
+  argTypes: {},
+  args: {
+    defaultValue: "default",
+  },
+};
+
+export const Input: StoryObj<typeof InputText> = {
+  name: "入力時",
+  argTypes: {},
+  args: {
+    value: "テスト",
+  },
+};
+
+export const Error: StoryObj<typeof InputText> = {
+  name: "エラー時",
+  argTypes: {},
+  args: {
+    ...Input.args,
+    state: "error",
+  },
+};
+
+export const ShowSuccess: StoryObj<typeof InputText> = {
+  name: "成功表示あり",
+  argTypes: {},
+  args: {
+    ...Input.args,
+    state: undefined,
+    showSuccess: true,
+  },
+};
+
+export const Disabled: StoryObj<typeof InputText> = {
+  name: "入力不可",
+  argTypes: {},
+  args: {
+    disabled: true,
+  },
+};

--- a/src/components/atoms/Input/InputText/InputText.tsx
+++ b/src/components/atoms/Input/InputText/InputText.tsx
@@ -1,0 +1,28 @@
+import { CheckCircleIcon, ExclamationCircleIcon } from "@heroicons/react/24/outline";
+
+import { INPUT_ICON_CLASS_NAME, INPUT_CONTAINER_CLASS_NAME } from "../const";
+import { InputTextProps } from "./type";
+
+export const InputText = ({
+  type = "text",
+  showSuccess = false,
+  state,
+  ...props
+}: InputTextProps) => {
+  const isSuccess = state !== "error" && showSuccess;
+
+  return (
+    <div className="relative">
+      <input
+        className={INPUT_CONTAINER_CLASS_NAME({ isSuccess, isError: state === "error" })}
+        type={type}
+        {...props}
+      />
+
+      {state === "error" && (
+        <ExclamationCircleIcon className={INPUT_ICON_CLASS_NAME({ isError: true })} />
+      )}
+      {isSuccess && <CheckCircleIcon className={INPUT_ICON_CLASS_NAME({ isSuccess: true })} />}
+    </div>
+  );
+};

--- a/src/components/atoms/Input/InputText/index.ts
+++ b/src/components/atoms/Input/InputText/index.ts
@@ -1,0 +1,1 @@
+export * from './InputText';

--- a/src/components/atoms/Input/InputText/type.ts
+++ b/src/components/atoms/Input/InputText/type.ts
@@ -1,0 +1,22 @@
+import { ComponentProps } from "react";
+import { InputStyleProps } from "../type";
+
+export type InputTextProps = InputStyleProps &
+  Pick<
+    ComponentProps<"input">,
+    | "id"
+    | "name"
+    | "maxLength"
+    | "autoComplete"
+    | "placeholder"
+    | "inputMode"
+    | "disabled"
+    | "onFocus"
+    | "onBlur"
+    | "defaultValue"
+    | "value"
+    | "onChange"
+  > & {
+    showSuccess?: boolean;
+    type?: "email" | "password" | "search" | "text";
+  };

--- a/src/components/atoms/Input/Textarea/Textarea.stories.tsx
+++ b/src/components/atoms/Input/Textarea/Textarea.stories.tsx
@@ -1,0 +1,76 @@
+import { action } from "@storybook/addon-actions";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Textarea } from "./Textarea";
+
+export default {
+  component: Textarea,
+  args: {
+    value: undefined,
+    onChange: action("onChange"),
+    onFocus: action("onFocus"),
+    onBlur: action("onBlur"),
+    disabled: false,
+    placeholder: "何か入力してください",
+    rows: 4,
+    maxLength: undefined,
+    autoComplete: "on",
+    showSuccess: false,
+    state: undefined,
+    resize: "vertical",
+  },
+  argTypes: {
+    state: {
+      control: {
+        type: "select",
+      },
+      options: [undefined, "success", "error"],
+    },
+    resize: {
+      control: {
+        type: "select",
+      },
+      options: ["vertical", "horizontal", "both", "none"],
+    },
+  },
+  parameters: {
+    controls: { expanded: true },
+  },
+} satisfies Meta<typeof Textarea>;
+
+export const Default: StoryObj<typeof Textarea> = {
+  name: "未入力時",
+  argTypes: {},
+};
+
+export const Inputed: StoryObj<typeof Textarea> = {
+  name: "入力時",
+  argTypes: {},
+  args: {
+    value: "Hello, World!",
+  },
+};
+
+export const Success: StoryObj<typeof Textarea> = {
+  name: "成功",
+  argTypes: {},
+  args: {
+    showSuccess: true,
+  },
+};
+
+export const Error: StoryObj<typeof Textarea> = {
+  name: "エラー",
+  argTypes: {},
+  args: {
+    state: "error",
+  },
+};
+
+export const Disable: StoryObj<typeof Textarea> = {
+  name: "非アクティブ",
+  argTypes: {},
+  args: {
+    disabled: true,
+  },
+};

--- a/src/components/atoms/Input/Textarea/Textarea.tsx
+++ b/src/components/atoms/Input/Textarea/Textarea.tsx
@@ -1,0 +1,18 @@
+import { TEXTAREA_CLASS_NAME } from "./const";
+
+import type { TextareaProps } from "./type";
+
+export const Textarea = ({ state, resize = "both", showSuccess, ...props }: TextareaProps) => {
+  const variants = {
+    isSuccess: state !== "error" && showSuccess,
+    isError: state === "error",
+    resize,
+  };
+
+  return (
+    <textarea
+      className={TEXTAREA_CLASS_NAME(variants)}
+      {...props}
+    />
+  );
+};

--- a/src/components/atoms/Input/Textarea/const.ts
+++ b/src/components/atoms/Input/Textarea/const.ts
@@ -1,0 +1,31 @@
+import clsx from "clsx";
+import { tv } from "tailwind-variants";
+
+export const TEXTAREA_CLASS_NAME = tv({
+  base: clsx(
+    "w-full rounded-lg border border-gray-light bg-white px-4 py-2 text-s text-black outline-0 transition-colors duration-300 ease-out placeholder:text-gray-dark",
+    "ring-offset-2 focus:ring-1 focus:ring-primary-600",
+    "disabled:cursor-not-allowed disabled:border-gray-light disabled:text-gray disabled:placeholder:text-gray",
+  ),
+  variants: {
+    isError: {
+      true: "border-red",
+      false: "",
+    },
+    isSuccess: {
+      true: "border-green",
+      false: "",
+    },
+    resize: {
+      vertical: "resize-y",
+      horizontal: "resize-x",
+      both: "resize",
+      none: "resize-none",
+    },
+  },
+  defaultVariants: {
+    isError: false,
+    isSuccess: false,
+    resize: "vertical",
+  },
+});

--- a/src/components/atoms/Input/Textarea/index.ts
+++ b/src/components/atoms/Input/Textarea/index.ts
@@ -1,0 +1,1 @@
+export * from "./Textarea";

--- a/src/components/atoms/Input/Textarea/type.ts
+++ b/src/components/atoms/Input/Textarea/type.ts
@@ -1,0 +1,18 @@
+import { ComponentProps } from "react";
+
+export type TextareaProps = Pick<
+  ComponentProps<"textarea">,
+  | "value"
+  | "onChange"
+  | "onFocus"
+  | "onBlur"
+  | "disabled"
+  | "placeholder"
+  | "rows"
+  | "maxLength"
+  | "autoComplete"
+> & {
+  state?: "error";
+  showSuccess?: boolean;
+  resize?: "vertical" | "horizontal" | "both" | "none";
+};

--- a/src/components/atoms/Input/Toggle/Toggle.stories.tsx
+++ b/src/components/atoms/Input/Toggle/Toggle.stories.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Toggle } from "./Toggle";
+import { ToggleProps } from "./type";
+
+/**
+ * Toggle自身が状態を持たないため、ラップして状態を渡す
+ * Wrap and pass the state to Toggle, Because it does not have a state.
+ */
+const LocalComponent = ({ value, onToggle, ...props }: ToggleProps) => {
+  const [localState, setLocalState] = useState(value);
+  return (
+    <Toggle
+      value={localState}
+      onToggle={(e) => {
+        setLocalState(!localState);
+        onToggle(e);
+      }}
+      {...props}
+    />
+  );
+};
+
+export default {
+  component: LocalComponent,
+  argTypes: {
+    onToggle: { action: "onToggle" },
+  },
+  args: {
+    value: true,
+    disabled: undefined,
+  },
+  parameters: {
+    controls: { expanded: true },
+  },
+} satisfies Meta<typeof Toggle>;
+
+export const Default: StoryObj<typeof Toggle> = {
+  name: "基本系",
+  args: {
+    value: true,
+  },
+};
+
+export const Disabled: StoryObj<typeof Toggle> = {
+  name: "非アクティブ",
+  args: {
+    value: true,
+    disabled: true,
+  },
+};

--- a/src/components/atoms/Input/Toggle/Toggle.tsx
+++ b/src/components/atoms/Input/Toggle/Toggle.tsx
@@ -1,0 +1,30 @@
+import { CheckIcon, XMarkIcon } from "@heroicons/react/24/outline";
+
+import {
+  TOGGLE_CIRCLE_CLASS_NAME,
+  TOGGLE_CONTAINER_CLASS_NAME,
+  TOGGLE_ICON_CLASS_NAME,
+} from "./const";
+import type { ToggleProps } from "./type";
+
+export const Toggle = ({ value, disabled, onToggle }: ToggleProps) => {
+  const iconClassName = TOGGLE_ICON_CLASS_NAME({ isValidValue: value, disabled });
+
+  return (
+    <label
+      className={TOGGLE_CONTAINER_CLASS_NAME({ disabled, isValidValue: value })}
+      aria-disabled={disabled}
+    >
+      <input
+        type="checkbox"
+        className="absolute h-0 w-0 opacity-0"
+        checked={value}
+        disabled={disabled}
+        onChange={onToggle}
+      />
+      <span className={TOGGLE_CIRCLE_CLASS_NAME({ isValidValue: value })}>
+        {value ? <CheckIcon className={iconClassName} /> : <XMarkIcon className={iconClassName} />}
+      </span>
+    </label>
+  );
+};

--- a/src/components/atoms/Input/Toggle/const.ts
+++ b/src/components/atoms/Input/Toggle/const.ts
@@ -1,0 +1,69 @@
+import { tv } from "tailwind-variants";
+
+export const TOGGLE_CONTAINER_CLASS_NAME = tv({
+  base: "flex rounded-full transition-colors w-10 p-[2px]",
+  variants: {
+    disabled: {
+      true: "cursor-not-allowed",
+      false: "cursor-pointer",
+    },
+    isValidValue: {
+      true: "bg-primary-600 aria-disabled:bg-disabled-primary",
+      false: "bg-gray-light",
+    },
+  },
+  defaultVariants: {
+    disabled: false,
+    isValidValue: true,
+  },
+});
+
+export const TOGGLE_CIRCLE_CLASS_NAME = tv({
+  base: "flex items-center justify-center rounded-full transition-all bg-white h-5 w-5",
+  variants: {
+    isValidValue: {
+      true: "translate-x-4",
+      false: "translate-x-0",
+    },
+  },
+});
+
+export const TOGGLE_ICON_CLASS_NAME = tv({
+  base: "h-3 w-3",
+  variants: {
+    isValidValue: {
+      true: "",
+      false: "",
+    },
+    disabled: {
+      true: "",
+      false: "",
+    },
+  },
+  compoundVariants: [
+    {
+      isValidValue: true,
+      disabled: true,
+      class: "text-disabled-primary",
+    },
+    {
+      isValidValue: true,
+      disabled: false,
+      class: "text-primary-600",
+    },
+    {
+      isValidValue: false,
+      disabled: true,
+      class: "text-gray-light",
+    },
+    {
+      isValidValue: false,
+      disabled: false,
+      class: "text-gray",
+    },
+  ],
+  defaultVariants: {
+    disabled: false,
+    isValidValue: true,
+  },
+});

--- a/src/components/atoms/Input/Toggle/index.ts
+++ b/src/components/atoms/Input/Toggle/index.ts
@@ -1,0 +1,1 @@
+export * from './Toggle';

--- a/src/components/atoms/Input/Toggle/type.ts
+++ b/src/components/atoms/Input/Toggle/type.ts
@@ -1,0 +1,6 @@
+import { ComponentProps } from "react";
+
+export type ToggleProps = Pick<ComponentProps<"input">, "disabled"> & {
+  value: boolean;
+  onToggle: NonNullable<ComponentProps<"input">["onChange"]>;
+};

--- a/src/components/atoms/Input/const.ts
+++ b/src/components/atoms/Input/const.ts
@@ -1,0 +1,34 @@
+import clsx from "clsx";
+import { tv } from "tailwind-variants";
+
+export const INPUT_CONTAINER_CLASS_NAME = tv({
+  base: clsx(
+    "inline-flex h-12 w-full items-center justify-between rounded-lg border border-gray-light bg-white p-4 text-sm leading-none outline-none",
+    "ring-offset-2 focus:text-black focus:ring-1 focus:ring-primary-600",
+    "disabled:cursor-not-allowed disabled:text-gray",
+  ),
+  variants: {
+    isError: {
+      true: "border-red",
+      false: "",
+    },
+    isSuccess: {
+      true: "border-green",
+      false: "",
+    },
+  },
+});
+
+export const INPUT_ICON_CLASS_NAME = tv({
+  base: "absolute right-4 top-1/2 h-4 w-4 -translate-y-2",
+  variants: {
+    isError: {
+      true: "text-red",
+      false: "",
+    },
+    isSuccess: {
+      true: "text-green",
+      false: "",
+    },
+  },
+});

--- a/src/components/atoms/Input/type.ts
+++ b/src/components/atoms/Input/type.ts
@@ -1,0 +1,4 @@
+// NOTE: InputやTextAreaの共通の型を定義する
+export type InputStyleProps = {
+    state?: 'error';
+};

--- a/src/components/atoms/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/atoms/ProgressBar/ProgressBar.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { ProgressBar } from "./ProgressBar";
+
+export default {
+  component: ProgressBar,
+  argTypes: {
+    color: {
+      options: ["default", "red", "yellow", "orange", "green", "blue", "black", "white", "gray"],
+      control: { type: "radio" },
+    },
+    size: {
+      options: ["small", "default", "large", "extraLarge"],
+      control: { type: "radio" },
+    },
+  },
+} satisfies Meta<typeof ProgressBar>;
+
+export const Default: StoryObj<typeof ProgressBar> = {
+  args: {
+    value: 30,
+    color: "yellow",
+    size: "large",
+  },
+};

--- a/src/components/atoms/ProgressBar/ProgressBar.tsx
+++ b/src/components/atoms/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,15 @@
+import { PROGRESS_BAR_WRAPPER_CLASS_NAME, PROGRESS_BAR_CLASS_NAME } from "./const";
+import { ProgressBarProps } from "./type";
+
+export const ProgressBar = ({ size, color, value = 0 }: ProgressBarProps) => {
+  const progressValue = Math.max(0, Math.min(100, value));
+
+  return (
+    <div className={PROGRESS_BAR_WRAPPER_CLASS_NAME({ size })}>
+      <div
+        className={PROGRESS_BAR_CLASS_NAME({ color, size })}
+        style={{ width: `${progressValue}%` }}
+      ></div>
+    </div>
+  );
+};

--- a/src/components/atoms/ProgressBar/const.ts
+++ b/src/components/atoms/ProgressBar/const.ts
@@ -1,0 +1,43 @@
+import { tv } from "tailwind-variants";
+
+export const PROGRESS_BAR_WRAPPER_CLASS_NAME = tv({
+  base: "w-full rounded-[16px] bg-gray-extraLight dark:bg-gray-extraDark",
+  variants: {
+    size: {
+      small: "h-1.5",
+      default: "h-2.5",
+      large: "h-4",
+      extraLarge: "h-6",
+    },
+  },
+  defaultVariants: {
+    size: "default",
+  },
+});
+
+export const PROGRESS_BAR_CLASS_NAME = tv({
+  base: "h-full rounded-[16px]",
+  variants: {
+    color: {
+      red: "bg-red",
+      yellow: "bg-yellow",
+      orange: "bg-orange",
+      green: "bg-green",
+      blue: "bg-blue",
+      black: "bg-black",
+      white: "bg-white",
+      gray: "bg-gray",
+      default: "bg-primary-500",
+    },
+    size: {
+      small: "h-1.5",
+      default: "h-2.5",
+      large: "h-4",
+      extraLarge: "h-6",
+    },
+  },
+  defaultVariants: {
+    color: "default",
+    size: "default",
+  },
+});

--- a/src/components/atoms/ProgressBar/index.ts
+++ b/src/components/atoms/ProgressBar/index.ts
@@ -1,0 +1,1 @@
+export * from "./ProgressBar";

--- a/src/components/atoms/ProgressBar/type.ts
+++ b/src/components/atoms/ProgressBar/type.ts
@@ -1,0 +1,5 @@
+export type ProgressBarProps = {
+  size: "small" | "default" | "large" | "extraLarge";
+  color: "default" | "red" | "yellow" | "orange" | "green" | "blue" | "black" | "white" | "gray";
+  value: number;
+};

--- a/src/components/atoms/RadioButton/RadioButton.stories.tsx
+++ b/src/components/atoms/RadioButton/RadioButton.stories.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { RadioButton } from "./RadioButton";
+
+export default {
+  component: RadioButton,
+  parameters: {
+    controls: { expanded: true },
+  },
+} satisfies Meta<typeof RadioButton>;
+
+export const Default: StoryObj<typeof RadioButton> = {
+  argTypes: {
+    name: {
+      type: "string",
+    },
+    children: {
+      type: "string",
+    },
+  },
+};
+
+const RADIO_GROUP_ITEM = {
+  name: "fruits",
+  items: ["apple", "orange"],
+};
+
+export const Groups = () => {
+  const [selected, setSelected] = useState("");
+  return (
+    <div className="flex items-center gap-x-2">
+      {RADIO_GROUP_ITEM.items.map((value) => (
+        <RadioButton
+          checked={selected === value}
+          name={RADIO_GROUP_ITEM.name}
+          value={value}
+          onChange={(e) => setSelected(e.target.value)}
+          key={value}
+        >
+          {value}
+        </RadioButton>
+      ))}
+    </div>
+  );
+};

--- a/src/components/atoms/RadioButton/RadioButton.tsx
+++ b/src/components/atoms/RadioButton/RadioButton.tsx
@@ -1,0 +1,21 @@
+import type { RadioButtonProps } from "./type";
+
+export const RadioButton = ({ children, name, onChange, value, checked }: RadioButtonProps) => {
+  return (
+    <label className="relative inline-flex cursor-pointer items-center gap-x-2">
+      <input
+        name={name}
+        type="radio"
+        onChange={onChange}
+        checked={checked}
+        className={
+          "peer h-4 w-4 cursor-pointer appearance-none rounded-full border border-gray-light checked:border-primary-600 checked:bg-primary-50"
+        }
+        value={value}
+        aria-checked={checked}
+      />
+      <div className="absolute left-1 hidden h-2 w-2 rounded-full bg-primary-600 peer-checked:block"></div>
+      <span className="font-noto-sans-cjk-jp text-s">{children}</span>
+    </label>
+  );
+};

--- a/src/components/atoms/RadioButton/index.ts
+++ b/src/components/atoms/RadioButton/index.ts
@@ -1,0 +1,1 @@
+export * from './RadioButton';

--- a/src/components/atoms/RadioButton/type.ts
+++ b/src/components/atoms/RadioButton/type.ts
@@ -1,0 +1,9 @@
+import { ComponentProps, ReactNode } from "react";
+
+export type RadioButtonProps = {
+  name: string;
+  checked: boolean;
+  children?: ReactNode;
+  value: string;
+  onChange: ComponentProps<"input">["onChange"];
+};

--- a/src/components/atoms/SearchInput/SearchInput.stories.tsx
+++ b/src/components/atoms/SearchInput/SearchInput.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { SearchInput } from "./SearchInput";
+
+export default {
+  component: SearchInput,
+  parameters: {
+    controls: { expanded: true },
+  },
+} satisfies Meta<typeof SearchInput>;
+
+export const Default: StoryObj<typeof SearchInput> = {
+  argTypes: {
+    onChange: { action: "search" },
+    inputSize: {
+      options: ["normal", "small"],
+      control: { type: "radio" },
+    },
+    inputStyle: {
+      options: ["filled", "outline"],
+      control: { type: "radio" },
+    },
+    placeholder: { control: "text" },
+  },
+  args: {
+    inputSize: "normal",
+    inputStyle: "filled",
+  },
+};

--- a/src/components/atoms/SearchInput/SearchInput.tsx
+++ b/src/components/atoms/SearchInput/SearchInput.tsx
@@ -1,0 +1,37 @@
+import { useId } from "react";
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+
+import { SEARCH_INPUT_CLASS_NAME } from "./const";
+import type { SearchInputProps } from "./type";
+
+export const SearchInput = ({
+  inputSize,
+  inputStyle,
+  label = "Search",
+  ...props
+}: SearchInputProps) => {
+  const id = useId();
+
+  const placeholder = props.placeholder || "Search";
+  return (
+    <div
+      role="search"
+      className="relative"
+    >
+      <label
+        className="absolute inset-y-0 left-0 flex items-center pl-3"
+        htmlFor={id}
+        aria-label={label}
+      >
+        <MagnifyingGlassIcon className="h-4 w-4 text-black" />
+      </label>
+      <input
+        id={id}
+        type="text"
+        placeholder={placeholder}
+        className={SEARCH_INPUT_CLASS_NAME({ inputSize, inputStyle })}
+        {...props}
+      />
+    </div>
+  );
+};

--- a/src/components/atoms/SearchInput/const.ts
+++ b/src/components/atoms/SearchInput/const.ts
@@ -1,0 +1,23 @@
+import clsx from "clsx";
+import { tv } from "tailwind-variants";
+
+export const SEARCH_INPUT_CLASS_NAME = tv({
+  base: clsx(
+    "block w-full rounded-3xl border border-gray-extraLight p-4 pl-9 text-s text-black",
+    "focus:border-gray focus:outline-none",
+  ),
+  variants: {
+    inputSize: {
+      normal: "py-3 text-s",
+      small: "py-2 text-xs",
+    },
+    inputStyle: {
+      filled: "bg-gray-extraLight",
+      outline: "",
+    },
+  },
+  defaultVariants: {
+    inputSize: "small",
+    inputStyle: "outline",
+  },
+});

--- a/src/components/atoms/SearchInput/index.ts
+++ b/src/components/atoms/SearchInput/index.ts
@@ -1,0 +1,1 @@
+export * from './SearchInput';

--- a/src/components/atoms/SearchInput/type.ts
+++ b/src/components/atoms/SearchInput/type.ts
@@ -1,0 +1,7 @@
+import { ComponentProps } from "react";
+
+export type SearchInputProps = ComponentProps<"input"> & {
+  inputSize: "normal" | "small";
+  inputStyle: "filled" | "outline";
+  label?: string;
+};

--- a/src/components/atoms/Selector/Selector.stories.tsx
+++ b/src/components/atoms/Selector/Selector.stories.tsx
@@ -1,0 +1,34 @@
+import type { StoryObj, Meta } from "@storybook/react";
+import { Selector } from "./Selector";
+
+export default {
+  component: Selector,
+} satisfies Meta<typeof Selector>;
+
+export const Default: StoryObj<typeof Selector> = {
+  argTypes: {
+    onSelect: { action: "onSelect" },
+  },
+  args: {
+    disabled: false,
+    size: "normal",
+    defaultLabel: "選択肢が入ります",
+    options: [
+      {
+        id: 1,
+        label: "オプション1",
+        value: "option1",
+      },
+      {
+        id: 2,
+        label: "オプション2",
+        value: "option2",
+      },
+      {
+        id: 3,
+        label: "オプション3",
+        value: "option3",
+      },
+    ],
+  },
+};

--- a/src/components/atoms/Selector/Selector.tsx
+++ b/src/components/atoms/Selector/Selector.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
+import {
+  ICON_CLASS_NAME,
+  LABEL_CLASS_NAME,
+  SELECTOR_BUTTON_CLASS_NAME,
+  SELECTOR_WRAPPER_CLASS_NAME,
+} from "./consts";
+import { SelectorList } from "./SelectorList";
+import type { OptionType, SelectorProps } from "./type";
+
+export const Selector = ({ size, options, defaultLabel, disabled, onSelect }: SelectorProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeLabel, setActiveLabel] = useState<OptionType["label"] | null>(null);
+  const [activeId, setActiveId] = useState<OptionType["id"] | null>(null);
+
+  const onClick = (option: OptionType) => {
+    setActiveLabel(option.label);
+    setActiveId(option.id);
+    onSelect(option.value);
+  };
+
+  return (
+    <div className={SELECTOR_WRAPPER_CLASS_NAME({ size })}>
+      <button
+        className={SELECTOR_BUTTON_CLASS_NAME({ size, disabled })}
+        disabled={disabled}
+        aria-disabled={disabled ? "true" : "false"}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <span className={LABEL_CLASS_NAME({ size, disabled, isActive: !!activeLabel })}>
+          {activeLabel || defaultLabel}
+        </span>
+        <ChevronDownIcon className={ICON_CLASS_NAME({ disabled })} />
+      </button>
+      {isOpen && (
+        <SelectorList
+          options={options}
+          activeId={activeId}
+          onClick={onClick}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/components/atoms/Selector/SelectorList/SelectorList.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorList.tsx
@@ -1,0 +1,20 @@
+import { SelectorListItem } from "./SelectorListItem";
+import type { SelectorListProps } from "./type";
+
+export const SelectorList = ({ options, activeId, onClick }: SelectorListProps) => {
+  return (
+    <ul
+      role="listbox"
+      className="flex h-52 w-full flex-col items-start justify-start rounded bg-white py-1 shadow-03"
+    >
+      {options.map((option) => (
+        <SelectorListItem
+          key={option.id}
+          option={option}
+          isActive={option.id === activeId}
+          onClick={onClick}
+        />
+      ))}
+    </ul>
+  );
+};

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/SelectorListItem.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/SelectorListItem.tsx
@@ -1,0 +1,21 @@
+import { CheckIcon } from "@heroicons/react/24/outline";
+import clsx from "clsx";
+import { LABEL_CLASS_NAME } from "./consts";
+import type { SelectorListItemProps } from "./type";
+
+export const SelectorListItem = ({ option, isActive, onClick }: SelectorListItemProps) => {
+  return (
+    <li
+      role="option"
+      className={clsx(
+        "box-border inline-flex h-10 w-full items-center justify-between truncate rounded-md bg-white px-4",
+        "hover:bg-primary-100 hover:text-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600",
+      )}
+      onClick={() => onClick(option)}
+      tabIndex={0}
+    >
+      <span className={LABEL_CLASS_NAME({ isActive })}>{option.label}</span>
+      {isActive && <CheckIcon className="relative h-4 w-4 text-primary-600" />}
+    </li>
+  );
+};

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/consts.ts
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/consts.ts
@@ -1,0 +1,14 @@
+import { tv } from "tailwind-variants";
+
+export const LABEL_CLASS_NAME = tv({
+  base: "text-center text-xs leading-none",
+  variants: {
+    isActive: {
+      true: "font-medium",
+      false: "font-regular",
+    },
+  },
+  defaultVariants: {
+    isActive: false,
+  },
+});

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/index.ts
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/index.ts
@@ -1,0 +1,1 @@
+export * from "./SelectorListItem";

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/type.ts
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/type.ts
@@ -1,0 +1,8 @@
+import { OptionType } from "../../type";
+import { SelectorListProps } from "../type";
+
+export type SelectorListItemProps = {
+  option: OptionType;
+  isActive: boolean;
+  onClick: SelectorListProps["onClick"];
+};

--- a/src/components/atoms/Selector/SelectorList/index.ts
+++ b/src/components/atoms/Selector/SelectorList/index.ts
@@ -1,0 +1,1 @@
+export * from "./SelectorList";

--- a/src/components/atoms/Selector/SelectorList/type.ts
+++ b/src/components/atoms/Selector/SelectorList/type.ts
@@ -1,0 +1,7 @@
+import { OptionType } from "../type";
+
+export type SelectorListProps = {
+  options: OptionType[];
+  activeId: OptionType["id"] | null;
+  onClick: (option: OptionType) => void;
+};

--- a/src/components/atoms/Selector/consts.ts
+++ b/src/components/atoms/Selector/consts.ts
@@ -1,0 +1,83 @@
+import clsx from "clsx";
+import { tv } from "tailwind-variants";
+
+export const SELECTOR_WRAPPER_CLASS_NAME = tv({
+  base: "inline-flex w-full flex-col items-start justify-start gap-2 bg-white",
+  variants: {
+    size: {
+      small: "h-8",
+      normal: "h-12",
+    },
+  },
+  defaultVariants: {
+    size: "normal",
+  },
+});
+
+export const SELECTOR_BUTTON_CLASS_NAME = tv({
+  base: clsx(
+    "inline-flex w-full items-center justify-between rounded-lg border p-4",
+    "focus:ring-1 focus:ring-primary-600 focus:ring-offset-2",
+  ),
+  variants: {
+    size: {
+      small: "h-8",
+      normal: "h-12",
+    },
+    disabled: {
+      true: "border-gray-extraLight",
+      false: "border-gray-light",
+    },
+  },
+  defaultVariants: {
+    size: "normal",
+    disabled: false,
+  },
+});
+
+export const LABEL_CLASS_NAME = tv({
+  base: "text-center font-normal leading-none truncate",
+  variants: {
+    size: {
+      small: "text-xs",
+      normal: "text-sm",
+    },
+    disabled: {
+      true: "text-gray",
+    },
+    isActive: {
+      true: "",
+      false: "",
+    },
+  },
+  compoundVariants: [
+    {
+      disabled: false,
+      isActive: true,
+      className: "",
+    },
+    {
+      disabled: false,
+      isActive: false,
+      className: "text-gray-dark",
+    },
+  ],
+  defaultVariants: {
+    size: "normal",
+    disabled: false,
+    isActive: false,
+  },
+});
+
+export const ICON_CLASS_NAME = tv({
+  base: "inline-flex h-4 w-4 items-center justify-center",
+  variants: {
+    disabled: {
+      true: "text-gray",
+      false: "text-gray-dark",
+    },
+  },
+  defaultVariants: {
+    disabled: false,
+  },
+});

--- a/src/components/atoms/Selector/index.ts
+++ b/src/components/atoms/Selector/index.ts
@@ -1,0 +1,1 @@
+export * from './Selector';

--- a/src/components/atoms/Selector/type.ts
+++ b/src/components/atoms/Selector/type.ts
@@ -1,0 +1,16 @@
+type LabelType = string;
+type ValueType = string | number;
+
+export type OptionType = {
+  id: number;
+  label: LabelType;
+  value: ValueType;
+};
+
+export type SelectorProps = {
+  size: "small" | "normal";
+  options: OptionType[];
+  defaultLabel: LabelType;
+  disabled?: boolean;
+  onSelect: (value: ValueType) => void;
+};

--- a/src/components/atoms/Spinner/Spinner.stories.tsx
+++ b/src/components/atoms/Spinner/Spinner.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Spinner } from "./Spinner";
+
+export default {
+  component: Spinner,
+  parameters: {
+    controls: { expanded: true },
+  },
+} satisfies Meta<typeof Spinner>;
+
+export const Default: StoryObj<typeof Spinner> = {
+  argTypes: {},
+  args: {
+    size: "medium",
+    theme: "primary",
+  },
+};

--- a/src/components/atoms/Spinner/Spinner.tsx
+++ b/src/components/atoms/Spinner/Spinner.tsx
@@ -1,0 +1,34 @@
+import { SPINNER_CLASS_NAME } from "./consts";
+import type { SpinnerProps } from "./type";
+
+export const Spinner = ({ size, theme, loading }: SpinnerProps) => {
+  if (!loading) return null;
+  return (
+    <span
+      role="status"
+      aria-label="Loading"
+    >
+      <svg
+        aria-hidden="true"
+        className={SPINNER_CLASS_NAME({ theme, size })}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10.9714"
+          transform="rotate(90 12 12)"
+          stroke="currentColor"
+          strokeWidth="2.05714"
+          fill="none"
+        />
+        <path
+          d="M12 24C13.5759 24 15.1363 23.6896 16.5922 23.0866C18.0481 22.4835 19.371 21.5996 20.4853 20.4853C21.5996 19.371 22.4835 18.0481 23.0866 16.5922C23.6896 15.1363 24 13.5759 24 12L21.94 12C21.94 13.3053 21.6829 14.5979 21.1834 15.8039C20.6838 17.0098 19.9517 18.1056 19.0286 19.0286C18.1056 19.9517 17.0099 20.6838 15.8039 21.1834C14.5979 21.6829 13.3053 21.94 12 21.94V24Z"
+          fill="currentFill"
+        />
+      </svg>
+    </span>
+  );
+};

--- a/src/components/atoms/Spinner/consts.ts
+++ b/src/components/atoms/Spinner/consts.ts
@@ -1,0 +1,16 @@
+import { tv } from "tailwind-variants";
+
+export const SPINNER_CLASS_NAME = tv({
+  base: "animate-spin text-[#000] text-opacity-20",
+  variants: {
+    size: {
+      small: "w-3 h-3",
+      medium: "w-4 h-4",
+      large: "w-6 h-6",
+    },
+    theme: {
+      white: "fill-gray-light",
+      primary: "fill-primary-600",
+    },
+  },
+});

--- a/src/components/atoms/Spinner/index.ts
+++ b/src/components/atoms/Spinner/index.ts
@@ -1,0 +1,1 @@
+export * from './Spinner';

--- a/src/components/atoms/Spinner/type.ts
+++ b/src/components/atoms/Spinner/type.ts
@@ -1,0 +1,5 @@
+export type SpinnerProps = {
+  size: "small" | "medium" | "large";
+  theme: "primary" | "white";
+  loading: boolean;
+};

--- a/src/components/molecules/NotificationBar/NotificationBar.stories.tsx
+++ b/src/components/molecules/NotificationBar/NotificationBar.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { NotificationBar } from "./NotificationBar";
+
+const meta: Meta<typeof NotificationBar> = {
+  component: NotificationBar,
+  argTypes: {
+    status: {
+      options: ["success", "info", "warning", "error"],
+      control: { type: "radio" },
+    },
+    notificationText: { control: "text" },
+    buttonText: { control: "text" },
+    onClose: { action: "closed" },
+    onClick: { action: "clicked" },
+    isUndoButtonShown: { options: [true, false], control: { type: "radio" } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof NotificationBar>;
+
+export const Primary: Story = {
+  args: {
+    status: "success",
+    notificationText: "テキストが入ります。テキストが入ります。テキストが入ります。",
+    buttonText: "ボタン",
+    isUndoButtonShown: true,
+  },
+};

--- a/src/components/molecules/NotificationBar/NotificationBar.tsx
+++ b/src/components/molecules/NotificationBar/NotificationBar.tsx
@@ -1,0 +1,38 @@
+import { XMarkIcon } from "@heroicons/react/24/solid";
+import { NotificationIcon } from "./NotificationIcon";
+import { NotificationBarProps } from "./type";
+import { getVariantStyles } from "./utils";
+
+export const NotificationBar = ({
+  status,
+  notificationText,
+  onClose,
+  onClick,
+  buttonText,
+  isUndoButtonShown = true,
+}: NotificationBarProps) => {
+  const { backgroundColor, color } = getVariantStyles(status);
+
+  return (
+    <div
+      className={`${backgroundColor} inline-flex items-center justify-start gap-4 rounded px-4 py-2`}
+    >
+      <NotificationIcon status={status} />
+      <span className="text-neutral-900 text-xs font-normal leading-tight">{notificationText}</span>
+      <div className="flex flex-none items-center justify-start gap-1">
+        {isUndoButtonShown && (
+          <button
+            onClick={onClick}
+            className={`${color} text-xs font-normal leading-3`}
+          >
+            {buttonText}
+          </button>
+        )}
+        <button onClick={onClose}>
+          <span className="sr-only">Close notification</span>
+          <XMarkIcon className="h-3 w-3 text-gray-dark" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/molecules/NotificationBar/NotificationIcon/NotificationIcon.tsx
+++ b/src/components/molecules/NotificationBar/NotificationIcon/NotificationIcon.tsx
@@ -1,0 +1,17 @@
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+} from "@heroicons/react/24/solid";
+import { IconStatus } from "./type";
+
+export const NotificationIcon = ({ status }: IconStatus) => {
+  return (
+    <>
+      {status === "success" && <CheckCircleIcon className="h-6 w-6 text-green" />}
+      {status === "info" && <ExclamationCircleIcon className="h-6 w-6 text-blue" />}
+      {status === "warning" && <ExclamationTriangleIcon className="h-6 w-6 text-yellow" />}
+      {status === "error" && <ExclamationCircleIcon className="h-6 w-6 text-red" />}
+    </>
+  );
+};

--- a/src/components/molecules/NotificationBar/NotificationIcon/index.ts
+++ b/src/components/molecules/NotificationBar/NotificationIcon/index.ts
@@ -1,0 +1,1 @@
+export * from "./NotificationIcon";

--- a/src/components/molecules/NotificationBar/NotificationIcon/type.ts
+++ b/src/components/molecules/NotificationBar/NotificationIcon/type.ts
@@ -1,0 +1,5 @@
+import { Status } from "../type";
+
+export type IconStatus = {
+  status: Status;
+};

--- a/src/components/molecules/NotificationBar/index.ts
+++ b/src/components/molecules/NotificationBar/index.ts
@@ -1,0 +1,1 @@
+export * from "./NotificationBar";

--- a/src/components/molecules/NotificationBar/type.ts
+++ b/src/components/molecules/NotificationBar/type.ts
@@ -1,0 +1,10 @@
+export type Status = "success" | "info" | "warning" | "error";
+
+export type NotificationBarProps = {
+  status: Status;
+  notificationText: string;
+  onClose: () => void;
+  onClick: () => void;
+  buttonText: string;
+  isUndoButtonShown: boolean;
+};

--- a/src/components/molecules/NotificationBar/utils.ts
+++ b/src/components/molecules/NotificationBar/utils.ts
@@ -1,0 +1,26 @@
+import { Status } from "./type";
+
+export const getVariantStyles = (status: Status): { backgroundColor: string; color: string } => {
+  switch (status) {
+    case "info":
+      return {
+        backgroundColor: "bg-blue-light",
+        color: "text-blue-dark",
+      };
+    case "success":
+      return {
+        backgroundColor: "bg-green-light",
+        color: "text-green-dark",
+      };
+    case "warning":
+      return {
+        backgroundColor: "bg-yellow-light",
+        color: "text-yellow-dark",
+      };
+    case "error":
+      return {
+        backgroundColor: "bg-red-light",
+        color: "text-red-dark",
+      };
+  }
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  margin: 0;
+  font-family: "Hiragino Sans", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,6 +1925,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@heroicons/react@npm:^2.0.18":
+  version: 2.0.18
+  resolution: "@heroicons/react@npm:2.0.18"
+  peerDependencies:
+    react: ">= 16"
+  checksum: 597e8668818623d568a302e343ef06b69f62ce297c14b88c2ebbfed0c0f00cd85ec44fae33ec8a249931b4e7dcf145743ae3198095a9f4682108de5155f5f4c3
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.11":
   version: 0.11.11
   resolution: "@humanwhocodes/config-array@npm:0.11.11"
@@ -11722,6 +11731,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "squad-ui@workspace:."
   dependencies:
+    "@heroicons/react": ^2.0.18
     "@storybook/addon-docs": ^7.4.6
     "@storybook/addon-essentials": ^7.4.6
     "@storybook/addon-interactions": ^7.4.6
@@ -12584,11 +12594,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
   version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=1f5320"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
+  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 変更点
- atoms・moleculesの追加
- heroiconsのinstall

## 挙動
全て無事に表示されている事が確認できました。

https://github.com/siva-squad/squad-ui/assets/61968429/09346a79-8108-49d6-a621-23b050f415fa

## 備考
まだsquad-beyond repoでマージ前のDropZoneは今回の移行に含まれていないです。

## Jiraチケット
https://siva-inc.atlassian.net/browse/DSD-25?atlOrigin=eyJpIjoiY2RhOWY1ZjQ4YTc5NGU2NWEyNzQ0ZmUxNGNiZWQwZTkiLCJwIjoiaiJ9