### PR TITLE
WorkflowにChromaticへのデプロイを追加

### DIFF
--- a/.github/actions/cache-node-modules/action.yml
+++ b/.github/actions/cache-node-modules/action.yml
@@ -1,0 +1,16 @@
+name: "cache node modules"
+description: "cache node modules"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/cache@v3
+      id: node_modules_cache_id
+      env:
+        cache-name: cache-node-modules
+      with:
+        path: "**/node_modules"
+        key: ${{ runner.os }}-nodejs-${{ hashFiles('**/yarn.lock') }}
+    - if: ${{ steps.node_modules_cache_id.outputs.cache-hit != 'true' }}
+      name: Install Dependencies
+      run: yarn install --immutable
+      shell: bash

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,14 @@
+name: "setup node"
+description: "setup node"
+inputs:
+  node-version:
+    default: "18.18.2"
+    required: false
+    description: "version of nodejs"
+runs:
+  using: "composite"
+  steps:
+    - name: Use Node.js ${{ inputs.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}

--- a/.github/workflows/chromatic_deploy.yml
+++ b/.github/workflows/chromatic_deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to Chromatic
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup node
+        uses: ./.github/actions/setup-node
+      - name: cache node_modules
+        uses: ./.github/actions/frontend-cache-nodemodules
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [setup]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: setup node
+        uses: ./.github/actions/setup-node
+      - name: cache node_modules
+        uses: ./.github/actions/frontend-cache-nodemodules
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,0 +1,37 @@
+name: Development CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup node
+        uses: ./.github/actions/setup-node
+      - name: cache node_modules
+        uses: ./.github/actions/cache-node-modules
+
+  chromatic:
+    runs-on: ubuntu-latest
+    needs: [setup]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: setup node
+        uses: ./.github/actions/setup-node
+      - name: cache node_modules
+        uses: ./.github/actions/cache-node-modules
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:check": "eslint .",
     "lint:fix": "eslint . --fix",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build",
+    "build-storybook": "storybook build",
     "test:watch": "vitest watch",
     "test:run": "vitest run",
     "generate:component": "hygen new fc"


### PR DESCRIPTION
## 概要
`package.json` の Storybook のビルドコマンドを更新し、Chromaticをワークフローに統合しました。

## 変更内容
- `package.json` での Storybook ビルドコマンドの変更
- ワークフローへのChromaticの統合

## 補足
- Chromaticの統合により、CI/CDプロセスでUIコンポーネントの視覚テストが可能になりました。

---

## Overview
We've made updates to the `package.json` by changing the Storybook build command and integrated Chromatic into our workflows.

## Changes
- Changed the Storybook build command in `package.json`
- Added Chromatic integrations to our workflows

## Notes
- With the Chromatic integration, we can now have visual testing for our UI components in the CI/CD process.
