### PR TITLE
chore: npmへ公開するworkflowを追加

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,36 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup node
+        uses: ./.github/actions/setup-node
+      - name: cache node_modules
+        uses: ./.github/actions/frontend-cache-node-modules
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [setup]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: ./.github/actions/setup-node
+      - name: cache node_modules
+        uses: ./.github/actions/frontend-cache-node-modules
+      - name: Build package
+        run: yarn build
+      - name: Publish package
+        run: yarn npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "squad-ui",
-  "version": "0.1.0",
+  "name": "@siva-squad-development/squad-ui",
+  "private": false,
+  "version": "0.1.1",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## 概要

`package.json` のパッケージ名を変更し、GitHub Actions上でのパッケージ公開ワークフローを追加しました。

## JIRAのチケット

https://siva-inc.atlassian.net/browse/DSD-28

## 変更内容

- `package.json` でのパッケージ名の変更
- GitHub Actionsにパッケージ公開ワークフローの追加

## 補足

- この変更により、新しいパッケージ名での公開が可能になりました。また、GitHub Actionsを使用しての自動パッケージ公開も設定されました。
