### PR TITLE
feat: LocalMenuItemにonClickを追加

### DIFF
--- a/src/components/molecules/LocalMenuItem/LocalMenuItem.tsx
+++ b/src/components/molecules/LocalMenuItem/LocalMenuItem.tsx
@@ -7,7 +7,10 @@ import {
 import type { LocalMenuItemProps } from "./type";
 
 export const LocalMenuItem = forwardRef<HTMLAnchorElement, LocalMenuItemProps>(
-  ({ id, icon, selectedIcon, title, isDisabled = false, isSelected = false, href }, ref) => {
+  (
+    { id, icon, selectedIcon, title, isDisabled = false, isSelected = false, href, onClick },
+    ref,
+  ) => {
     const iconUI = useMemo(() => {
       if (isSelected) {
         return selectedIcon || icon;
@@ -21,6 +24,7 @@ export const LocalMenuItem = forwardRef<HTMLAnchorElement, LocalMenuItemProps>(
         className={MENUITEM_CONTAINER_CLASS_NAME({ isSelected, isDisabled })}
         ref={ref}
         id={id}
+        onClick={() => id && onClick?.(id)}
         {...(!isDisabled && { href })}
       >
         {icon && (

--- a/src/components/molecules/LocalMenuItem/type.ts
+++ b/src/components/molecules/LocalMenuItem/type.ts
@@ -8,4 +8,5 @@ export type LocalMenuItemProps = {
   isDisabled?: boolean;
   isSelected?: boolean;
   href: string;
+  onClick?: (id: string) => void;
 };


### PR DESCRIPTION
## 概要 / Overview

<!-- 
実装内容のSummaryを記述する
Describe the summary of the implementation
-->

navigation系のコンポーネントからLocalMenuItemにonClick処理を渡したい要件があったためpropsを更新した

### Figmaのリンク / Figma Link
<!-- 
Figmaの該当箇所のリンクを貼る
Please attach the relevant link from Figma.
-->

特になし

### Jira のチケット / Jira Ticket

<!-- 
Jiraのチケットのリンクを貼る
Link to Jira ticket
 -->

https://siva-inc.atlassian.net/browse/RPD-25

## 変更内容 / Changes

<!--
  変更内容を記述する
  Describe your changes here
-->

- LocalMenuItemのpropsにonClickを追加
- LocalMenuItemのaタグクリック時にonClickの呼び出しを追加

## その他 / Other

<!-- 
  その他困ったこととか伝えたいことを何でも
  Anything else you want to share?
 -->
