### PR TITLE
[GlobalNavigation] menuとaccountの表示切り替え対応

### DIFF
--- a/src/components/organisms/GlobalNavigation/GlobalNavigation.stories.tsx
+++ b/src/components/organisms/GlobalNavigation/GlobalNavigation.stories.tsx
@@ -105,7 +105,6 @@ export const Simplified: StoryObj<typeof GlobalNavigation> = {
         navigationType: "connection",
       },
     ],
-    showAccount: false,
-    showMenu: false,
+    hasOnlyLogo: true,
   },
 };

--- a/src/components/organisms/GlobalNavigation/GlobalNavigation.stories.tsx
+++ b/src/components/organisms/GlobalNavigation/GlobalNavigation.stories.tsx
@@ -73,3 +73,39 @@ export const Default: StoryObj<typeof GlobalNavigation> = {
     ],
   },
 };
+
+export const Simplified: StoryObj<typeof GlobalNavigation> = {
+  args: {
+    groups: [],
+    items: [
+      {
+        href: "#",
+        title: "ダッシュボード",
+        id: "1",
+        navigationType: "default",
+        hasChevron: false,
+      },
+      {
+        href: "",
+        title: "beyondページ",
+        id: "2",
+        navigationType: "beyond",
+      },
+      {
+        href: "#",
+        title: "ドメイン",
+        id: "3",
+        navigationType: "default",
+        hasChevron: false,
+      },
+      {
+        href: "",
+        title: "外部連携",
+        id: "4",
+        navigationType: "connection",
+      },
+    ],
+    showAccount: false,
+    showMenu: false,
+  },
+};

--- a/src/components/organisms/GlobalNavigation/GlobalNavigation.tsx
+++ b/src/components/organisms/GlobalNavigation/GlobalNavigation.tsx
@@ -10,12 +10,7 @@ import { NavigationListUI } from "./components/NavigationListUI";
 import { useRichMenuDialog } from "./hooks";
 import type { GlobalNavigationProps } from "./type";
 
-export const GlobalNavigation = ({
-  items,
-  groups,
-  showAccount = true,
-  showMenu = true,
-}: GlobalNavigationProps) => {
+export const GlobalNavigation = ({ items, groups, hasOnlyLogo = false }: GlobalNavigationProps) => {
   const { isDesktop, isMobile } = useScreenSize();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
@@ -29,7 +24,7 @@ export const GlobalNavigation = ({
         className="flex items-center gap-x-6 border-b border-gray-light bg-white px-4 py-2"
         ref={headerRef}
       >
-        {isMobile && showMenu && (
+        {isMobile && !hasOnlyLogo && (
           <button
             onClick={() => setIsSidebarOpen(true)}
             ref={triggerRef}
@@ -41,13 +36,13 @@ export const GlobalNavigation = ({
           </button>
         )}
         <BrandLogo />
-        {isDesktop && showMenu && (
+        {isDesktop && !hasOnlyLogo && (
           <NavigationListUI
             items={items}
             groups={groups}
           />
         )}
-        {showAccount && (
+        {!hasOnlyLogo && (
           <div
             className="relative ml-auto"
             data-dropdown-id="account"
@@ -68,7 +63,7 @@ export const GlobalNavigation = ({
           </div>
         )}
       </header>
-      {showMenu && (
+      {!hasOnlyLogo && (
         <GlobalSidebar
           items={items}
           isOpen={isMobile && isSidebarOpen}

--- a/src/components/organisms/GlobalNavigation/GlobalNavigation.tsx
+++ b/src/components/organisms/GlobalNavigation/GlobalNavigation.tsx
@@ -10,7 +10,12 @@ import { NavigationListUI } from "./components/NavigationListUI";
 import { useRichMenuDialog } from "./hooks";
 import type { GlobalNavigationProps } from "./type";
 
-export const GlobalNavigation = ({ items, groups }: GlobalNavigationProps) => {
+export const GlobalNavigation = ({
+  items,
+  groups,
+  showAccount = true,
+  showMenu = true,
+}: GlobalNavigationProps) => {
   const { isDesktop, isMobile } = useScreenSize();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
@@ -24,7 +29,7 @@ export const GlobalNavigation = ({ items, groups }: GlobalNavigationProps) => {
         className="flex items-center gap-x-6 border-b border-gray-light bg-white px-4 py-2"
         ref={headerRef}
       >
-        {isMobile && (
+        {isMobile && showMenu && (
           <button
             onClick={() => setIsSidebarOpen(true)}
             ref={triggerRef}
@@ -36,37 +41,41 @@ export const GlobalNavigation = ({ items, groups }: GlobalNavigationProps) => {
           </button>
         )}
         <BrandLogo />
-        {isDesktop && (
+        {isDesktop && showMenu && (
           <NavigationListUI
             items={items}
             groups={groups}
           />
         )}
-        <div
-          className="relative ml-auto"
-          data-dropdown-id="account"
-          ref={(el) => noCloseRefs.current.push(el)}
-        >
-          <GlobalAccount
-            userId="1"
-            userName="田中 太郎"
-            teamName="Squad beyondチーム"
-            onClick={() => toggleDialog("account")}
-          />
-          <RichMenu
-            isOpen={richMenuState.key === "account" && richMenuState.isOpen}
-            navigationType="account"
-            absolute
-            anchor="right"
-          />
-        </div>
+        {showAccount && (
+          <div
+            className="relative ml-auto"
+            data-dropdown-id="account"
+            ref={(el) => noCloseRefs.current.push(el)}
+          >
+            <GlobalAccount
+              userId="1"
+              userName="田中 太郎"
+              teamName="Squad beyondチーム"
+              onClick={() => toggleDialog("account")}
+            />
+            <RichMenu
+              isOpen={richMenuState.key === "account" && richMenuState.isOpen}
+              navigationType="account"
+              absolute
+              anchor="right"
+            />
+          </div>
+        )}
       </header>
-      <GlobalSidebar
-        items={items}
-        isOpen={isMobile && isSidebarOpen}
-        onClose={() => setIsSidebarOpen(false)}
-        ref={sidebarRef}
-      />
+      {showMenu && (
+        <GlobalSidebar
+          items={items}
+          isOpen={isMobile && isSidebarOpen}
+          onClose={() => setIsSidebarOpen(false)}
+          ref={sidebarRef}
+        />
+      )}
     </>
   );
 };

--- a/src/components/organisms/GlobalNavigation/type.ts
+++ b/src/components/organisms/GlobalNavigation/type.ts
@@ -6,5 +6,7 @@ export type GlobalNavigationProps = {
   groups: RichMenuProps["groups"];
   items: MergeType<ListItemProps, RichMenuProps>[];
   selectedId: string;
+  showAccount?: boolean;
+  showMenu?: boolean;
   onChangeSelectedId?: (id: string) => void;
 };

--- a/src/components/organisms/GlobalNavigation/type.ts
+++ b/src/components/organisms/GlobalNavigation/type.ts
@@ -6,7 +6,6 @@ export type GlobalNavigationProps = {
   groups: RichMenuProps["groups"];
   items: MergeType<ListItemProps, RichMenuProps>[];
   selectedId: string;
-  showAccount?: boolean;
-  showMenu?: boolean;
+  hasOnlyLogo?: boolean;
   onChangeSelectedId?: (id: string) => void;
 };


### PR DESCRIPTION
## 概要 / Overview
menuとaccountの表示切り替え対応
ウイイレで使用

<!-- 
実装内容のSummaryを記述する
Describe the summary of the implementation
-->
### Modes
| Default |  Simplified (NEW✨) |
| ---- | ---- |
<img width="1328" alt="スクリーンショット 2023-11-13 19 45 58" src="https://github.com/siva-squad/squad-ui/assets/61968429/b09012a7-9b56-4b6f-b2c7-b42b78a84048"> | <img width="1328" alt="スクリーンショット 2023-11-13 19 46 08" src="https://github.com/siva-squad/squad-ui/assets/61968429/0e953e53-582f-426d-a448-bb778076a99f"> |

### Figmaのリンク / Figma Link
<!-- 
Figmaの該当箇所のリンクを貼る
Please attach the relevant link from Figma.
-->
https://www.figma.com/file/5KaykTqeXvtv3yGH9NV2Ol/Design-System?type=design&node-id=404-3323&mode=dev

### Jira のチケット / Jira Ticket

<!-- 
Jiraのチケットのリンクを貼る
Link to Jira ticket
 -->
https://siva-inc.atlassian.net/browse/WE-4?atlOrigin=eyJpIjoiNWFmMWRlYTQ1NGM3NDRjZjk2Y2ZmOTc3MmRkYTkzNGMiLCJwIjoiaiJ9