### PR TITLE
Task/add forward ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/Anchor/Anchor.tsx
+++ b/src/components/atoms/Anchor/Anchor.tsx
@@ -1,59 +1,70 @@
+import { forwardRef } from "react";
 import { Spinner } from "../Spinner";
 import { ANCHOR_CHILDREN_CLASS_NAME, ANCHOR_CLASS_NAME, ANCHOR_ICON_CLASS_NAME } from "./const";
 import { AnchorProps } from "./type";
 
-export const Anchor = ({
-  children,
-  icon,
-  size,
-  theme,
-  iconPosition = "left",
-  isDisabled = false,
-  href,
-  isLoading = false,
-}: AnchorProps) => {
-  const showIcon = !isLoading && !!icon;
-  const spinnerProps = {
-    // NOTE: ボタンのサイズが`large`でテキストがない場合はアイコンを大きく表示するため
-    size: size === "large" && children ? "medium" : size,
-    theme: ["red", "primary"].includes(theme) ? "white" : "primary",
-  } as const;
+export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(
+  (
+    {
+      children,
+      icon,
+      size,
+      theme,
+      iconPosition = "left",
+      isDisabled = false,
+      href,
+      isLoading = false,
+      onClick,
+    },
+    ref,
+  ) => {
+    const showIcon = !isLoading && !!icon;
+    const spinnerProps = {
+      // NOTE: ボタンのサイズが`large`でテキストがない場合はアイコンを大きく表示するため
+      size: size === "large" && children ? "medium" : size,
+      theme: ["red", "primary"].includes(theme) ? "white" : "primary",
+    } as const;
 
-  return (
-    <a
-      {...(!isDisabled && { href })}
-      className={ANCHOR_CLASS_NAME({
-        theme,
-        isLoading,
-        hasChildren: !!children,
-        size,
-        isDisabled,
-      })}
-    >
-      {showIcon && iconPosition === "left" && (
-        <span className={ANCHOR_ICON_CLASS_NAME({ hasChildren: !!children, size, theme })}>
-          {icon}
-        </span>
-      )}
-      <Spinner
-        loading={isLoading}
-        {...spinnerProps}
-      />
-      {children && (
-        <span
-          className={ANCHOR_CHILDREN_CLASS_NAME({
-            size,
-            theme,
-          })}
-        >
-          {isLoading ? "読み込み中..." : children}
-        </span>
-      )}
-      {showIcon && iconPosition === "right" && (
-        <span className={ANCHOR_ICON_CLASS_NAME({ hasChildren: !!children, size, theme })}>
-          {icon}
-        </span>
-      )}
-    </a>
-  );
-};
+    return (
+      <a
+        {...(!isDisabled && { href })}
+        className={ANCHOR_CLASS_NAME({
+          theme,
+          isLoading,
+          hasChildren: !!children,
+          size,
+          isDisabled,
+        })}
+        ref={ref}
+        onClick={onClick}
+      >
+        {showIcon && iconPosition === "left" && (
+          <span className={ANCHOR_ICON_CLASS_NAME({ hasChildren: !!children, size, theme })}>
+            {icon}
+          </span>
+        )}
+        <Spinner
+          loading={isLoading}
+          {...spinnerProps}
+        />
+        {children && (
+          <span
+            className={ANCHOR_CHILDREN_CLASS_NAME({
+              size,
+              theme,
+            })}
+          >
+            {isLoading ? "読み込み中..." : children}
+          </span>
+        )}
+        {showIcon && iconPosition === "right" && (
+          <span className={ANCHOR_ICON_CLASS_NAME({ hasChildren: !!children, size, theme })}>
+            {icon}
+          </span>
+        )}
+      </a>
+    );
+  },
+);
+
+Anchor.displayName = "Anchor";

--- a/src/components/atoms/Anchor/type.ts
+++ b/src/components/atoms/Anchor/type.ts
@@ -3,7 +3,7 @@ import { ComponentProps, ReactNode } from "react";
 type Theme = "white" | "primary" | "red" | "no-background";
 type Size = "small" | "medium" | "large";
 
-export type AnchorProps = Pick<ComponentProps<"a">, "href" | "children"> & {
+export type AnchorProps = Pick<ComponentProps<"a">, "href" | "children" | "onClick"> & {
   icon?: ReactNode;
   isDisabled?: boolean;
   theme: Theme;


### PR DESCRIPTION
## 概要 / Overview

- Added `forwardRef` and `onClick` to `Anchor` component to be compatible with NextJS `Link`
- Discussion why it needs the change: https://github.com/siva-squad/squadbeyond-frontend/pull/25#discussion_r1398743239
- NextJS documentation: https://nextjs.org/docs/pages/api-reference/components/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag

### package.jsonのversion

- [x] 上げました
