### PR TITLE
chore:developmentのCIからChromaticへのデプロイを削除

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -31,7 +31,3 @@ jobs:
         uses: ./.github/actions/setup-node
       - name: cache node_modules
         uses: ./.github/actions/cache-node-modules
-      - name: Publish to Chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
## 概要 / Overview

Chromaticのビルド時間を減らすためにChromaticへのデプロイタイミングを制限した

### package.jsonのversion

- [ ] 上げました

## 変更内容 / Changes

- workflows/development.ymlでのchromaticのデプロイを削除

