### PR TITLE
Task/fix dialog button props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2023-12-08-2",
+  "version": "0.10.2023-12-12-1",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/molecules/Dialog/Dialog.stories.tsx
+++ b/src/components/molecules/Dialog/Dialog.stories.tsx
@@ -16,8 +16,16 @@ export const Default: StoryObj<typeof Dialog> = {
   args: {
     children: "With a little bit of text",
     title: "Dialog",
-    cancelButtonText: "キャンセル",
-    saveButtonText: "保存する",
+    cancelButtonProps: {
+      text: "キャンセル",
+      onClose: () => console.log("close"),
+      disabled: false,
+    },
+    saveButtonProps: {
+      text: "保存する",
+      onSave: () => console.log("save"),
+      disabled: false,
+    },
     isOpen: true,
     theme: "default",
   },
@@ -67,8 +75,16 @@ export const RedTheme: StoryObj<typeof Dialog> = {
   args: {
     children: "With a little bit of text",
     title: "Dialog",
-    cancelButtonText: "キャンセル",
-    saveButtonText: "保存する",
+    cancelButtonProps: {
+      text: "キャンセル",
+      onClose: () => console.log("close"),
+      disabled: false,
+    },
+    saveButtonProps: {
+      text: "保存する",
+      onSave: () => console.log("save"),
+      disabled: false,
+    },
     isOpen: true,
     theme: "red",
   },
@@ -129,9 +145,8 @@ export const Controlled = () => {
       </Button>
       <Dialog
         title="Base Dialog example"
-        onClose={() => setIsOpen(false)}
-        cancelButtonText="キャンセル"
-        saveButtonText="保存する"
+        cancelButtonProps={{ onClose: () => setIsOpen(false), text: "キャンセル" }}
+        saveButtonProps={{ onSave: () => console.log("save"), text: "保存する" }}
         isOpen={isOpen}
         theme="default"
       >
@@ -160,9 +175,8 @@ export const ControlledWithScroll = () => {
       </Button>
       <Dialog
         title="Base Dialog example"
-        onClose={() => setIsOpen(false)}
-        cancelButtonText="キャンセル"
-        saveButtonText="保存する"
+        cancelButtonProps={{ onClose: () => setIsOpen(false), text: "キャンセル" }}
+        saveButtonProps={{ onSave: () => console.log("save"), text: "保存する" }}
         isOpen={isOpen}
         theme="default"
       >
@@ -221,9 +235,8 @@ export const ControlledWithSelectorAndInput = () => {
       </Button>
       <Dialog
         title="Base Dialog example"
-        onClose={() => setIsOpen(false)}
-        cancelButtonText="キャンセル"
-        saveButtonText="保存する"
+        cancelButtonProps={{ onClose: () => setIsOpen(false), text: "キャンセル" }}
+        saveButtonProps={{ onSave: () => console.log("save"), text: "保存する" }}
         isOpen={isOpen}
         theme="default"
       >

--- a/src/components/molecules/Dialog/Dialog.stories.tsx
+++ b/src/components/molecules/Dialog/Dialog.stories.tsx
@@ -19,7 +19,6 @@ export const Default: StoryObj<typeof Dialog> = {
     cancelButtonProps: {
       text: "キャンセル",
       onClose: () => console.log("close"),
-      disabled: false,
     },
     saveButtonProps: {
       text: "保存する",
@@ -78,7 +77,6 @@ export const RedTheme: StoryObj<typeof Dialog> = {
     cancelButtonProps: {
       text: "キャンセル",
       onClose: () => console.log("close"),
-      disabled: false,
     },
     saveButtonProps: {
       text: "保存する",
@@ -137,7 +135,6 @@ export const DisabledSaveButton: StoryObj<typeof Dialog> = {
     cancelButtonProps: {
       text: "キャンセル",
       onClose: () => console.log("close"),
-      disabled: false,
     },
     saveButtonProps: {
       text: "保存する",

--- a/src/components/molecules/Dialog/Dialog.stories.tsx
+++ b/src/components/molecules/Dialog/Dialog.stories.tsx
@@ -130,6 +130,65 @@ export const RedTheme: StoryObj<typeof Dialog> = {
   ],
 };
 
+export const DisabledSaveButton: StoryObj<typeof Dialog> = {
+  args: {
+    children: "With a little bit of text",
+    title: "Dialog",
+    cancelButtonProps: {
+      text: "キャンセル",
+      onClose: () => console.log("close"),
+      disabled: false,
+    },
+    saveButtonProps: {
+      text: "保存する",
+      onSave: () => console.log("save"),
+      disabled: true,
+    },
+    isOpen: true,
+    theme: "default",
+  },
+  decorators: [
+    (Story) => (
+      <div
+        data-testid="root"
+        style={{ margin: "3em" }}
+      >
+        <div>
+          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Soluta ad architecto vitae
+          deleniti odit labore maiores sapiente error nesciunt suscipit quod, eum veritatis. Minus,
+          molestiae dignissimos. Asperiores consequatur laudantium sit! Lorem ipsum dolor sit amet
+          consectetur adipisicing elit. Modi molestias autem sit tenetur repudiandae pariatur optio
+          recusandae sapiente. Nisi, obcaecati! Commodi sint voluptates voluptatum sequi sunt in rem
+          facilis a! Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus dignissimos
+          quibusdam veniam voluptate ut, nihil pariatur qui enim dolorem ea vero atque
+          necessitatibus aut, excepturi magnam reiciendis explicabo aperiam veritatis!
+        </div>
+        <Story />
+        <div>
+          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Soluta ad architecto vitae
+          deleniti odit labore maiores sapiente error nesciunt suscipit quod, eum veritatis. Minus,
+          molestiae dignissimos. Asperiores consequatur laudantium sit! Lorem ipsum dolor sit amet
+          consectetur adipisicing elit. Modi molestias autem sit tenetur repudiandae pariatur optio
+          recusandae sapiente. Nisi, obcaecati! Commodi sint voluptates voluptatum sequi sunt in rem
+          facilis a! Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus dignissimos
+          quibusdam veniam voluptate ut, nihil pariatur qui enim dolorem ea vero atque
+          necessitatibus aut, excepturi magnam reiciendis explicabo aperiam veritatis!
+        </div>
+        <div>
+          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Soluta ad architecto vitae
+          deleniti odit labore maiores sapiente error nesciunt suscipit quod, eum veritatis. Minus,
+          molestiae dignissimos. Asperiores consequatur laudantium sit! Lorem ipsum dolor sit amet
+          consectetur adipisicing elit. Modi molestias autem sit tenetur repudiandae pariatur optio
+          recusandae sapiente. Nisi, obcaecati! Commodi sint voluptates voluptatum sequi sunt in rem
+          facilis a! Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus dignissimos
+          quibusdam veniam voluptate ut, nihil pariatur qui enim dolorem ea vero atque
+          necessitatibus aut, excepturi magnam reiciendis explicabo aperiam veritatis!
+        </div>
+      </div>
+    ),
+  ],
+};
+
 export const Controlled = () => {
   // Actual Use case
   const [isOpen, setIsOpen] = useState(false);

--- a/src/components/molecules/Dialog/Dialog.test.tsx
+++ b/src/components/molecules/Dialog/Dialog.test.tsx
@@ -40,6 +40,18 @@ describe("Dialog", () => {
     expect(closeDialogCallback).toHaveBeenCalled();
   });
 
+  test("calls save dialog callback function when clicking on save button", async () => {
+    const user = userEvent.setup();
+    const saveDialogCallback = vi.fn();
+    render(<Dialog onSave={saveDialogCallback} />);
+
+    const saveButton = screen.getByRole("button", { name: "保存する" });
+
+    await user.click(saveButton);
+
+    expect(saveDialogCallback).toHaveBeenCalled();
+  });
+
   test("in context with button and state", async () => {
     const user = userEvent.setup();
     render(<Controlled />);

--- a/src/components/molecules/Dialog/Dialog.test.tsx
+++ b/src/components/molecules/Dialog/Dialog.test.tsx
@@ -31,7 +31,7 @@ describe("Dialog", () => {
   test("calls close dialog callback function when clicking on the background", async () => {
     const user = userEvent.setup();
     const closeDialogCallback = vi.fn();
-    render(<Dialog onClose={closeDialogCallback} />);
+    render(<Dialog cancelButtonProps={{ onClose: closeDialogCallback, text: "" }} />);
 
     const background = screen.getByTestId("dialog-background");
 
@@ -40,10 +40,22 @@ describe("Dialog", () => {
     expect(closeDialogCallback).toHaveBeenCalled();
   });
 
+  test("calls close dialog callback function when clicking on cancel button", async () => {
+    const user = userEvent.setup();
+    const closeDialogCallback = vi.fn();
+    render(<Dialog cancelButtonProps={{ onClose: closeDialogCallback, text: "キャンセル" }} />);
+
+    const cancelButton = screen.getByRole("button", { name: "キャンセル" });
+
+    await user.click(cancelButton);
+
+    expect(closeDialogCallback).toHaveBeenCalled();
+  });
+
   test("calls save dialog callback function when clicking on save button", async () => {
     const user = userEvent.setup();
     const saveDialogCallback = vi.fn();
-    render(<Dialog onSave={saveDialogCallback} />);
+    render(<Dialog saveButtonProps={{ onSave: saveDialogCallback, text: "保存する" }} />);
 
     const saveButton = screen.getByRole("button", { name: "保存する" });
 

--- a/src/components/molecules/Dialog/Dialog.tsx
+++ b/src/components/molecules/Dialog/Dialog.tsx
@@ -52,7 +52,6 @@ export const Dialog = ({
                   background="white"
                   size="medium"
                   onClick={cancelButtonProps.onClose}
-                  disabled={cancelButtonProps.disabled}
                 >
                   {cancelButtonProps.text}
                 </Button>

--- a/src/components/molecules/Dialog/Dialog.tsx
+++ b/src/components/molecules/Dialog/Dialog.tsx
@@ -10,6 +10,7 @@ export const Dialog = ({
   children,
   title,
   onClose,
+  onSave,
   cancelButtonText,
   saveButtonText,
   isOpen,
@@ -59,6 +60,7 @@ export const Dialog = ({
                 <Button
                   theme={theme === "default" ? "primary" : "red"}
                   size="medium"
+                  onClick={onSave}
                 >
                   {saveButtonText}
                 </Button>

--- a/src/components/molecules/Dialog/Dialog.tsx
+++ b/src/components/molecules/Dialog/Dialog.tsx
@@ -9,10 +9,8 @@ import type { DialogProps } from "./type";
 export const Dialog = ({
   children,
   title,
-  onClose,
-  onSave,
-  cancelButtonText,
-  saveButtonText,
+  saveButtonProps,
+  cancelButtonProps,
   isOpen,
   theme = "default",
 }: DialogProps) => {
@@ -38,7 +36,7 @@ export const Dialog = ({
           <div
             data-testid="dialog-background"
             className="absolute inset-0 bg-black opacity-60"
-            onClick={onClose}
+            onClick={cancelButtonProps.onClose}
           />
           <div
             className="overflow-hidden rounded-2xl"
@@ -53,16 +51,18 @@ export const Dialog = ({
                   theme={theme === "default" ? "white" : "gray"}
                   background="white"
                   size="medium"
-                  onClick={onClose}
+                  onClick={cancelButtonProps.onClose}
+                  disabled={cancelButtonProps.disabled}
                 >
-                  {cancelButtonText}
+                  {cancelButtonProps.text}
                 </Button>
                 <Button
                   theme={theme === "default" ? "primary" : "red"}
                   size="medium"
-                  onClick={onSave}
+                  onClick={saveButtonProps.onSave}
+                  disabled={saveButtonProps.disabled}
                 >
-                  {saveButtonText}
+                  {saveButtonProps.text}
                 </Button>
               </div>
             </div>

--- a/src/components/molecules/Dialog/type.ts
+++ b/src/components/molecules/Dialog/type.ts
@@ -1,12 +1,22 @@
 import { ReactNode } from "react";
 
+import { ButtonProps } from "@components/atoms/Button/type";
+
+type SaveButtonProps = Pick<ButtonProps, "disabled"> & {
+  onSave: () => void;
+  text: string;
+};
+
+type CancelButtonProps = Pick<ButtonProps, "disabled"> & {
+  onClose: () => void;
+  text: string;
+};
+
 export type DialogProps = {
   children: string | ReactNode;
   title: string;
-  onClose: () => void;
-  onSave: () => void;
-  cancelButtonText: string;
-  saveButtonText: string;
+  saveButtonProps: SaveButtonProps;
+  cancelButtonProps: CancelButtonProps;
   isOpen: boolean;
   theme?: "default" | "red";
 };

--- a/src/components/molecules/Dialog/type.ts
+++ b/src/components/molecules/Dialog/type.ts
@@ -7,7 +7,7 @@ type SaveButtonProps = Pick<ButtonProps, "disabled"> & {
   text: string;
 };
 
-type CancelButtonProps = Pick<ButtonProps, "disabled"> & {
+type CancelButtonProps = {
   onClose: () => void;
   text: string;
 };

--- a/src/components/molecules/Dialog/type.ts
+++ b/src/components/molecules/Dialog/type.ts
@@ -4,6 +4,7 @@ export type DialogProps = {
   children: string | ReactNode;
   title: string;
   onClose: () => void;
+  onSave: () => void;
   cancelButtonText: string;
   saveButtonText: string;
   isOpen: boolean;


### PR DESCRIPTION
## 概要 / Overview

- I changed the props so that an object for both buttons can be received, to add a little bit more flexibility when working with the dialog and needing to change the button
- Especially being able to disable the save button for confirmation reasons and to actually get the save function callback

- ダイアログを操作していてボタンを変更する必要があるときに、もう少し柔軟性を持たせるために、両方のボタンのオブジェクトを受け取れるようにpropsを変更しました。
- 特に、確認のために保存ボタンを無効にしたり、実際に保存関数のコールバックを取得できるようにしました。

### package.jsonのversion

- [ ] 上げました
