### PR TITLE
Change type of InputElement's descriptionText

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2023-12-18-1",
+  "version": "0.10.2023-12-19-1",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2023-12-19-1",
+  "version": "0.10.2023-12-21-1",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/molecules/InputElement/InputElement.stories.tsx
+++ b/src/components/molecules/InputElement/InputElement.stories.tsx
@@ -15,7 +15,7 @@ export default {
     errorText: {
       type: "string",
     },
-    descriptionText: {
+    description: {
       type: "string",
     },
     showRequired: {
@@ -46,7 +46,34 @@ export const Default: StoryObj<typeof InputElement> = {
   args: {
     htmlFor: "testId",
     label: "タイトル",
-    descriptionText: "説明文が入ります",
+    description: "説明文が入ります",
+    errorText: "エラーテキストが入ります",
+    render: ({ htmlFor }) => (
+      <InputText
+        placeholder="プレイスホルダー"
+        id={htmlFor}
+      />
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-[500px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const WithHtmlForDescription: StoryObj<typeof InputElement> = {
+  args: {
+    htmlFor: "testId",
+    label: "タイトル",
+    description: (
+      <p className="text-xs leading-normal">
+        <a href="#">リンク</a>
+        が入ります
+      </p>
+    ),
     errorText: "エラーテキストが入ります",
     render: ({ htmlFor }) => (
       <InputText

--- a/src/components/molecules/InputElement/InputElement.stories.tsx
+++ b/src/components/molecules/InputElement/InputElement.stories.tsx
@@ -70,7 +70,12 @@ export const WithHtmlForDescription: StoryObj<typeof InputElement> = {
     label: "タイトル",
     description: (
       <p className="text-xs leading-normal">
-        <a href="#">リンク</a>
+        <a
+          href="#"
+          className="text-primary-600"
+        >
+          リンク
+        </a>
         が入ります
       </p>
     ),

--- a/src/components/molecules/InputElement/InputElement.tsx
+++ b/src/components/molecules/InputElement/InputElement.tsx
@@ -7,7 +7,7 @@ export const InputElement = ({
   render,
   label,
   errorText,
-  descriptionText,
+  description,
   showLabel = true,
   showRequired = true,
   isRequired = true,
@@ -37,8 +37,10 @@ export const InputElement = ({
           />
         )}
       </div>
-      {!!descriptionText && (
-        <p className="text-xs leading-normal text-gray-dark">{descriptionText}</p>
+      {!!description && typeof description === "string" ? (
+        <p className="text-xs leading-normal text-gray-dark">{description}</p>
+      ) : (
+        description
       )}
       {elementUI}
       {!!errorText && <p className="text-xs leading-normal text-red">{errorText}</p>}

--- a/src/components/molecules/InputElement/InputElement.tsx
+++ b/src/components/molecules/InputElement/InputElement.tsx
@@ -37,11 +37,12 @@ export const InputElement = ({
           />
         )}
       </div>
-      {!!description && typeof description === "string" ? (
-        <p className="text-xs leading-normal text-gray-dark">{description}</p>
-      ) : (
-        description
-      )}
+      {!!description &&
+        (typeof description === "string" ? (
+          <p className="text-xs leading-normal text-gray-dark">{description}</p>
+        ) : (
+          description
+        ))}
       {elementUI}
       {!!errorText && <p className="text-xs leading-normal text-red">{errorText}</p>}
     </div>

--- a/src/components/molecules/InputElement/type.ts
+++ b/src/components/molecules/InputElement/type.ts
@@ -8,7 +8,7 @@ type FormType = {
 export type InputElementProps = {
   label: string;
   errorText?: string;
-  descriptionText?: string;
+  description?: string | ReactElement;
   showRequired?: boolean;
   showLabel?: boolean;
   children?: ReactElement;


### PR DESCRIPTION
## 概要 / Overview

- dialog等でInputElementのdescriptionTextに文字列以外にもリンクが入る場合があるため、stringとReactElementもとれるように変更
  - それに伴い、`descriptionText`から`description`に変更
- storyに`description`が`<a>`タグリンクを含む場合も追加
<!--
実装内容のSummaryを記述する
Describe the summary of the implementation
-->

### package.jsonのversion

- [x] 上げました

### Figmaのリンク / Figma Link
https://www.figma.com/file/8mkhOMue3eAQS6H11k6wQ8/Re-design?type=design&node-id=1994-75188&mode=dev
<!--
Figmaの該当箇所のリンクを貼る
Please attach the relevant link from Figma.
-->

### Jira のチケット / Jira Ticket

<!--
Jiraのチケットのリンクを貼る
Link to Jira ticket
 -->



<!--
  変更内容を記述する
  Describe your changes here
-->

## その他 / Other
squadbeyond-frontendに対して既に`InputElement`を使用している部分には影響がある変更なので、マージ後にsquadbeyond-frontendの方で対応する
（今回は影響が小さいのですぐに対応できるが、大きい場合はどういったフローで対応すべきなのか。。。）

<!--
  その他困ったこととか伝えたいことを何でも
  Anything else you want to share?
 -->
