### PR TITLE
feat: Add Breadcrumbs components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2023-01-10-1",
+  "version": "0.10.2024-01-10-2",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.stories.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { BreadcrumbItem } from "./BreadcrumbItem";
+
+export default {
+  component: BreadcrumbItem,
+  parameters: {
+    controls: { expanded: true },
+  },
+  argTypes: {},
+} satisfies Meta<typeof BreadcrumbItem>;
+
+export const Default: StoryObj<typeof BreadcrumbItem> = {
+  args: {},
+};
+
+

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.stories.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import clsx from "clsx";
 import { BreadcrumbItem } from "./BreadcrumbItem";
 
 export default {
@@ -13,5 +14,53 @@ export default {
 export const Default: StoryObj<typeof BreadcrumbItem> = {
   args: {
     children: <a href="/">サンプルテキスト</a>,
+    clickable: true,
+    disabledLastStyle: true,
+  },
+};
+
+export const All = () => (
+  <div className={clsx("flex flex-col gap-5", "[&_h3]:mb-3")}>
+    <section>
+      <h3 className="font-bold">Default</h3>
+      <BreadcrumbItem disabledLastStyle>
+        <a href="/">サンプルテキスト</a>
+      </BreadcrumbItem>
+    </section>
+    <section>
+      <h3 className="font-bold">Hover</h3>
+      <BreadcrumbItem
+        id="hover"
+        disabledLastStyle
+      >
+        <a href="/">サンプルテキスト</a>
+      </BreadcrumbItem>
+    </section>
+    <section>
+      <h3 className="font-bold">Focus</h3>
+      <BreadcrumbItem
+        id="focus"
+        disabledLastStyle
+      >
+        <a href="/">サンプルテキスト</a>
+      </BreadcrumbItem>
+    </section>
+    <section>
+      <h3 className="font-bold">Pressed(Active)</h3>
+      <BreadcrumbItem
+        id="active"
+        disabledLastStyle
+      >
+        <a href="/">サンプルテキスト</a>
+      </BreadcrumbItem>
+    </section>
+  </div>
+);
+
+All.parameters = {
+  pseudo: {
+    hover: "#hover",
+    focus: "#focus",
+    active: "#active",
   },
 };

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.stories.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.stories.tsx
@@ -11,7 +11,7 @@ export default {
 } satisfies Meta<typeof BreadcrumbItem>;
 
 export const Default: StoryObj<typeof BreadcrumbItem> = {
-  args: {},
+  args: {
+    children: <a href="/">サンプルテキスト</a>,
+  },
 };
-
-

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.test.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.test.tsx
@@ -1,15 +1,16 @@
 import { composeStories } from "@storybook/react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, test } from "vitest";
+import { render } from "@testing-library/react";
+import { describe, test } from "vitest";
 
 import * as BreadcrumbItemStories from "./BreadcrumbItem.stories";
 
-const { Default: BreadcrumbItem } = composeStories(BreadcrumbItemStories);
+const { Default: BreadcrumbItem, All: AllBreadcrumbItems } = composeStories(BreadcrumbItemStories);
 
 describe("BreadcrumbItem", () => {
-
   test("renders", async () => {
     render(<BreadcrumbItem />);
   });
-
+  test("renders all", async () => {
+    render(<AllBreadcrumbItems />);
+  });
 });

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.test.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.test.tsx
@@ -1,0 +1,15 @@
+import { composeStories } from "@storybook/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import * as BreadcrumbItemStories from "./BreadcrumbItem.stories";
+
+const { Default: BreadcrumbItem } = composeStories(BreadcrumbItemStories);
+
+describe("BreadcrumbItem", () => {
+
+  test("renders", async () => {
+    render(<BreadcrumbItem />);
+  });
+
+});

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.test.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.test.tsx
@@ -1,16 +1,15 @@
 import { composeStories } from "@storybook/react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, test } from "vitest";
 
 import * as BreadcrumbItemStories from "./BreadcrumbItem.stories";
 
-const { Default: BreadcrumbItem, All: AllBreadcrumbItems } = composeStories(BreadcrumbItemStories);
+const { Default: BreadcrumbItem } = composeStories(BreadcrumbItemStories);
 
 describe("BreadcrumbItem", () => {
   test("renders", async () => {
     render(<BreadcrumbItem />);
-  });
-  test("renders all", async () => {
-    render(<AllBreadcrumbItems />);
+    const anchor = screen.getByRole("link", { name: "サンプルテキスト" });
+    expect(anchor).toBeInTheDocument();
   });
 });

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
@@ -6,9 +6,11 @@ export const BreadcrumbItem = ({
   children,
   clickable = true,
   disabledLastStyle = false,
+  id,
 }: BreadcrumbItemProps) => {
   return (
     <li
+      id={id}
       className={clsx(
         "cursor-pointer list-none text-xs font-regular leading-none text-gray-dark",
         "hover:underline",

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
@@ -1,0 +1,7 @@
+import { clsx } from 'clsx';
+
+import type { BreadcrumbItemProps } from './type';
+
+export const BreadcrumbItem = ({}: BreadcrumbItemProps) => {
+  return <></>;
+}

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
@@ -2,7 +2,11 @@ import { clsx } from "clsx";
 
 import type { BreadcrumbItemProps } from "./type";
 
-export const BreadcrumbItem = ({ children, clickable = true }: BreadcrumbItemProps) => {
+export const BreadcrumbItem = ({
+  children,
+  clickable = true,
+  disabledLastStyle = false,
+}: BreadcrumbItemProps) => {
   return (
     <li
       className={clsx(
@@ -10,7 +14,8 @@ export const BreadcrumbItem = ({ children, clickable = true }: BreadcrumbItemPro
         "hover:underline",
         "focus:underline",
         "active:text-gray-extraDark active:underline",
-        "last:pointer-events-none last:cursor-default last:text-gray-extraDark last:no-underline",
+        !disabledLastStyle &&
+          "last:pointer-events-none last:cursor-default last:text-gray-extraDark last:no-underline",
         !clickable && "hover:no-underline",
       )}
     >

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
@@ -4,15 +4,16 @@ import type { BreadcrumbItemProps } from "./type";
 
 export const BreadcrumbItem = ({ children }: BreadcrumbItemProps) => {
   return (
-    <div
+    <li
       className={clsx(
-        "text-xs font-regular leading-none text-gray-dark",
+        "cursor-pointer list-none text-xs font-regular leading-none text-gray-dark",
         "hover:underline",
         "focus:underline",
         "active:text-gray-extraDark active:underline",
+        "last:pointer-events-none last:cursor-default last:text-gray-extraDark last:no-underline",
       )}
     >
       {children}
-    </div>
+    </li>
   );
 };

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
@@ -1,7 +1,18 @@
-import { clsx } from 'clsx';
+import { clsx } from "clsx";
 
-import type { BreadcrumbItemProps } from './type';
+import type { BreadcrumbItemProps } from "./type";
 
-export const BreadcrumbItem = ({}: BreadcrumbItemProps) => {
-  return <></>;
-}
+export const BreadcrumbItem = ({ children }: BreadcrumbItemProps) => {
+  return (
+    <div
+      className={clsx(
+        "text-xs font-regular leading-none text-gray-dark",
+        "hover:underline",
+        "focus:underline",
+        "active:text-gray-extraDark active:underline",
+      )}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/atoms/BreadcrumbItem/BreadcrumbItem.tsx
@@ -2,7 +2,7 @@ import { clsx } from "clsx";
 
 import type { BreadcrumbItemProps } from "./type";
 
-export const BreadcrumbItem = ({ children }: BreadcrumbItemProps) => {
+export const BreadcrumbItem = ({ children, clickable = true }: BreadcrumbItemProps) => {
   return (
     <li
       className={clsx(
@@ -11,6 +11,7 @@ export const BreadcrumbItem = ({ children }: BreadcrumbItemProps) => {
         "focus:underline",
         "active:text-gray-extraDark active:underline",
         "last:pointer-events-none last:cursor-default last:text-gray-extraDark last:no-underline",
+        !clickable && "hover:no-underline",
       )}
     >
       {children}

--- a/src/components/atoms/BreadcrumbItem/index.ts
+++ b/src/components/atoms/BreadcrumbItem/index.ts
@@ -1,0 +1,1 @@
+export * from './BreadcrumbItem';

--- a/src/components/atoms/BreadcrumbItem/type.ts
+++ b/src/components/atoms/BreadcrumbItem/type.ts
@@ -4,4 +4,5 @@ export type BreadcrumbItemProps = {
   children: ReactNode;
   clickable?: boolean;
   disabledLastStyle?: boolean;
+  id?: string;
 };

--- a/src/components/atoms/BreadcrumbItem/type.ts
+++ b/src/components/atoms/BreadcrumbItem/type.ts
@@ -1,2 +1,5 @@
+import { ReactNode } from "react";
+
 export type BreadcrumbItemProps = {
-}
+  children: ReactNode;
+};

--- a/src/components/atoms/BreadcrumbItem/type.ts
+++ b/src/components/atoms/BreadcrumbItem/type.ts
@@ -3,4 +3,5 @@ import { ReactNode } from "react";
 export type BreadcrumbItemProps = {
   children: ReactNode;
   clickable?: boolean;
+  disabledLastStyle?: boolean;
 };

--- a/src/components/atoms/BreadcrumbItem/type.ts
+++ b/src/components/atoms/BreadcrumbItem/type.ts
@@ -2,4 +2,5 @@ import { ReactNode } from "react";
 
 export type BreadcrumbItemProps = {
   children: ReactNode;
+  clickable?: boolean;
 };

--- a/src/components/atoms/BreadcrumbItem/type.ts
+++ b/src/components/atoms/BreadcrumbItem/type.ts
@@ -1,0 +1,2 @@
+export type BreadcrumbItemProps = {
+}

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Breadcrumbs } from "./Breadcrumbs";
+
+export default {
+  component: Breadcrumbs,
+  parameters: {
+    controls: { expanded: true },
+  },
+  argTypes: {},
+} satisfies Meta<typeof Breadcrumbs>;
+
+export const Default: StoryObj<typeof Breadcrumbs> = {
+  args: {},
+};
+
+

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,6 +1,7 @@
 import { BreadcrumbItem } from "@components/atoms/BreadcrumbItem";
 import type { Meta, StoryObj } from "@storybook/react";
 
+import clsx from "clsx";
 import { Breadcrumbs } from "./Breadcrumbs";
 
 export default {
@@ -14,14 +15,44 @@ export default {
 export const Default: StoryObj<typeof Breadcrumbs> = {
   args: {
     children: [
-      <BreadcrumbItem key="home">Home</BreadcrumbItem>,
-      <BreadcrumbItem key="hoge_1">Hoge1</BreadcrumbItem>,
-      <BreadcrumbItem key="hoge_2">Hoge2</BreadcrumbItem>,
-      <BreadcrumbItem key="hoge_3">Hoge3</BreadcrumbItem>,
-      <BreadcrumbItem key="group">Before last</BreadcrumbItem>,
-      <BreadcrumbItem key="group_1">Last</BreadcrumbItem>,
+      <BreadcrumbItem key="home">ホーム</BreadcrumbItem>,
+      <BreadcrumbItem key="sample-1">サンプルテキスト1</BreadcrumbItem>,
+      <BreadcrumbItem key="sample-2">サンプルテキスト2</BreadcrumbItem>,
+      <BreadcrumbItem key="sample-3">サンプルテキスト3</BreadcrumbItem>,
+      <BreadcrumbItem key="before-last">1つ前のページ</BreadcrumbItem>,
+      <BreadcrumbItem key="current">今いるページ</BreadcrumbItem>,
     ],
     overflowCount: 5,
     sliceEnd: -3,
+  },
+};
+
+export const All = () => (
+  <div className={clsx("flex flex-col gap-5", "[&_h3]:mb-3 [&_h3]:font-bold")}>
+    <section>
+      <h3>コンテンツが4個未満の表示</h3>
+      <Breadcrumbs>
+        <BreadcrumbItem key="home">ホーム</BreadcrumbItem>
+        <BreadcrumbItem key="before-last">1つ前のページ</BreadcrumbItem>
+        <BreadcrumbItem key="current">今いるページ</BreadcrumbItem>
+      </Breadcrumbs>
+    </section>
+    <section>
+      <h3>コンテンツが4個以上の表示</h3>
+      <Breadcrumbs id="hover">
+        <BreadcrumbItem key="home">ホーム</BreadcrumbItem>
+        <BreadcrumbItem key="sample-1">サンプルテキスト1</BreadcrumbItem>
+        <BreadcrumbItem key="sample-2">サンプルテキスト2</BreadcrumbItem>
+        <BreadcrumbItem key="sample-3">サンプルテキスト3</BreadcrumbItem>
+        <BreadcrumbItem key="before-last">1つ前のページ</BreadcrumbItem>
+        <BreadcrumbItem key="current">今いるページ</BreadcrumbItem>
+      </Breadcrumbs>
+    </section>
+  </div>
+);
+
+All.parameters = {
+  pseudo: {
+    hover: "#hover-overflow",
   },
 };

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,3 +1,4 @@
+import { BreadcrumbItem } from "@components/atoms/BreadcrumbItem";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Breadcrumbs } from "./Breadcrumbs";
@@ -11,7 +12,14 @@ export default {
 } satisfies Meta<typeof Breadcrumbs>;
 
 export const Default: StoryObj<typeof Breadcrumbs> = {
-  args: {},
+  args: {
+    children: [
+      <BreadcrumbItem key="home">Home</BreadcrumbItem>,
+      <BreadcrumbItem key="hoge_1">Hoge1</BreadcrumbItem>,
+      <BreadcrumbItem key="hoge_2">Hoge2</BreadcrumbItem>,
+      <BreadcrumbItem key="hoge_3">Hoge3</BreadcrumbItem>,
+      <BreadcrumbItem key="group">Before last</BreadcrumbItem>,
+      <BreadcrumbItem key="group_1">Last</BreadcrumbItem>,
+    ],
+  },
 };
-
-

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -15,12 +15,24 @@ export default {
 export const Default: StoryObj<typeof Breadcrumbs> = {
   args: {
     children: [
-      <BreadcrumbItem key="home">ホーム</BreadcrumbItem>,
-      <BreadcrumbItem key="sample-1">サンプルテキスト1</BreadcrumbItem>,
-      <BreadcrumbItem key="sample-2">サンプルテキスト2</BreadcrumbItem>,
-      <BreadcrumbItem key="sample-3">サンプルテキスト3</BreadcrumbItem>,
-      <BreadcrumbItem key="before-last">1つ前のページ</BreadcrumbItem>,
-      <BreadcrumbItem key="current">今いるページ</BreadcrumbItem>,
+      <BreadcrumbItem key="home">
+        <a href="/">ホーム</a>
+      </BreadcrumbItem>,
+      <BreadcrumbItem key="sample-1">
+        <a href="/">サンプルテキスト1</a>
+      </BreadcrumbItem>,
+      <BreadcrumbItem key="sample-2">
+        <a href="/">サンプルテキスト2</a>
+      </BreadcrumbItem>,
+      <BreadcrumbItem key="sample-3">
+        <a href="/">サンプルテキスト3</a>
+      </BreadcrumbItem>,
+      <BreadcrumbItem key="before-last">
+        <a href="/">1つ前のページ</a>
+      </BreadcrumbItem>,
+      <BreadcrumbItem key="current">
+        <a href="/">今いるページ</a>
+      </BreadcrumbItem>,
     ],
     overflowCount: 5,
     sliceEnd: -3,

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -15,10 +15,7 @@ export const Default: StoryObj<typeof Breadcrumbs> = {
   args: {
     children: [
       <BreadcrumbItem key="home">Home</BreadcrumbItem>,
-      <BreadcrumbItem key="hoge_1">Hoge1</BreadcrumbItem>,
-      <BreadcrumbItem key="hoge_2">Hoge2</BreadcrumbItem>,
       <BreadcrumbItem key="hoge_3">Hoge3</BreadcrumbItem>,
-      <BreadcrumbItem key="group">Before last</BreadcrumbItem>,
       <BreadcrumbItem key="group_1">Last</BreadcrumbItem>,
     ],
   },

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -15,8 +15,13 @@ export const Default: StoryObj<typeof Breadcrumbs> = {
   args: {
     children: [
       <BreadcrumbItem key="home">Home</BreadcrumbItem>,
+      <BreadcrumbItem key="hoge_1">Hoge1</BreadcrumbItem>,
+      <BreadcrumbItem key="hoge_2">Hoge2</BreadcrumbItem>,
       <BreadcrumbItem key="hoge_3">Hoge3</BreadcrumbItem>,
+      <BreadcrumbItem key="group">Before last</BreadcrumbItem>,
       <BreadcrumbItem key="group_1">Last</BreadcrumbItem>,
     ],
+    overflowCount: 5,
+    sliceEnd: -3,
   },
 };

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,15 +1,13 @@
 import { composeStories } from "@storybook/react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, test } from "vitest";
+import { render } from "@testing-library/react";
+import { describe, test } from "vitest";
 
 import * as BreadcrumbsStories from "./Breadcrumbs.stories";
 
 const { Default: Breadcrumbs } = composeStories(BreadcrumbsStories);
 
 describe("Breadcrumbs", () => {
-
   test("renders", async () => {
     render(<Breadcrumbs />);
   });
-
 });

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from "@storybook/react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, test } from "vitest";
 
 import * as BreadcrumbsStories from "./Breadcrumbs.stories";
@@ -9,5 +9,17 @@ const { Default: Breadcrumbs } = composeStories(BreadcrumbsStories);
 describe("Breadcrumbs", () => {
   test("renders", async () => {
     render(<Breadcrumbs />);
+    const anchors = [
+      screen.getByRole("link", { name: "ホーム" }),
+      screen.getByRole("link", { name: "サンプルテキスト1" }),
+      screen.getByRole("link", { name: "サンプルテキスト2" }),
+      screen.getByRole("link", { name: "サンプルテキスト3" }),
+      screen.getByRole("link", { name: "1つ前のページ" }),
+      screen.getByRole("link", { name: "今いるページ" }),
+    ];
+
+    anchors.forEach((anchor) => {
+      expect(anchor).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,0 +1,15 @@
+import { composeStories } from "@storybook/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import * as BreadcrumbsStories from "./Breadcrumbs.stories";
+
+const { Default: Breadcrumbs } = composeStories(BreadcrumbsStories);
+
+describe("Breadcrumbs", () => {
+
+  test("renders", async () => {
+    render(<Breadcrumbs />);
+  });
+
+});

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
@@ -19,7 +19,13 @@ export const Breadcrumbs = ({ children, separator = "/" }: BreadcrumbsProps) => 
           content={
             <div className="rounded-lg bg-white p-2 shadow-04">
               <ul className={clsx("flex flex-col gap-2", "[&>li]:p-2")}>
-                {overflowItems.map((child) => child)}
+                {overflowItems.map((child) => (
+                  <BreadcrumbItem
+                    disabledLastStyle
+                    key={child.key}
+                    {...child.props}
+                  />
+                ))}
               </ul>
             </div>
           }

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
@@ -1,14 +1,8 @@
 import { BreadcrumbItem } from "@components/atoms/BreadcrumbItem";
 import { Popover } from "@components/molecules/Popover";
 import clsx from "clsx";
+import { DEFAULTS } from "./const";
 import type { BreadcrumbsProps } from "./type";
-
-const DEFAULTS = {
-  OVERFLOW_COUNT: 4,
-  SLICE_END: -2,
-  OVERFLOW_TEXT: "...",
-  SEPARATOR: "/",
-} as const;
 
 export const Breadcrumbs = ({
   children,
@@ -26,11 +20,10 @@ export const Breadcrumbs = ({
         id={id}
       >
         {children
-          .map((child, index) => [
+          .flatMap((child, index) => [
             child,
             <BreadcrumbItem key={`breadcrumbsItem-${index}-separator`}>{separator}</BreadcrumbItem>,
           ])
-          .flat()
           .slice(0, -1)}
       </ol>
     );

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
@@ -40,6 +40,7 @@ export const Breadcrumbs = ({ children, separator = "/" }: BreadcrumbsProps) => 
   const afterItems = children.slice(SLICE_END);
 
   const items = [beforeItem, el(), ...afterItems]
+    .filter((child) => child != null)
     .map((child, index) => [
       child,
       <BreadcrumbItem key={`breadcrumbsItem-${index}-separator`}>{separator}</BreadcrumbItem>,

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
@@ -3,12 +3,35 @@ import { Popover } from "@components/molecules/Popover";
 import clsx from "clsx";
 import type { BreadcrumbsProps } from "./type";
 
-const OVERFLOW_COUNT = 4 as const;
-const SLICE_END = -2 as const;
-const OVERFLOW_TEXT = "..." as const;
+const DEFAULTS = {
+  OVERFLOW_COUNT: 4,
+  SLICE_END: -2,
+  OVERFLOW_TEXT: "...",
+  SEPARATOR: "/",
+} as const;
 
-export const Breadcrumbs = ({ children, separator = "/" }: BreadcrumbsProps) => {
-  const overflowItems = children.length >= OVERFLOW_COUNT ? children.slice(1, SLICE_END) : null;
+export const Breadcrumbs = ({
+  children,
+  separator = DEFAULTS.SEPARATOR,
+  overflowCount = DEFAULTS.OVERFLOW_COUNT,
+  overflowText = DEFAULTS.OVERFLOW_TEXT,
+  sliceEnd = DEFAULTS.SLICE_END,
+  disableOverflow = false,
+}: BreadcrumbsProps) => {
+  if (disableOverflow)
+    return (
+      <ol className="flex gap-2">
+        {children
+          .map((child, index) => [
+            child,
+            <BreadcrumbItem key={`breadcrumbsItem-${index}-separator`}>{separator}</BreadcrumbItem>,
+          ])
+          .flat()
+          .slice(0, -1)}
+      </ol>
+    );
+
+  const overflowItems = children.length >= overflowCount ? children.slice(1, sliceEnd) : null;
   const el = () => {
     return overflowItems != null ? (
       <BreadcrumbItem
@@ -31,13 +54,13 @@ export const Breadcrumbs = ({ children, separator = "/" }: BreadcrumbsProps) => 
           }
           position={"bottom"}
         >
-          {OVERFLOW_TEXT}
+          {overflowText}
         </Popover>
       </BreadcrumbItem>
     ) : null;
   };
   const beforeItem = children[0];
-  const afterItems = children.slice(SLICE_END);
+  const afterItems = children.slice(sliceEnd);
 
   const items = [beforeItem, el(), ...afterItems]
     .filter((child) => child != null)

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
@@ -1,8 +1,11 @@
 import { BreadcrumbItem } from "@components/atoms/BreadcrumbItem";
+import { Popover } from "@components/molecules/Popover";
+import clsx from "clsx";
 import type { BreadcrumbsProps } from "./type";
 
 const OVERFLOW_COUNT = 4 as const;
 const SLICE_END = -2 as const;
+const OVERFLOW_TEXT = "..." as const;
 
 export const Breadcrumbs = ({ children, separator = "/" }: BreadcrumbsProps) => {
   const overflowItems = children.length >= OVERFLOW_COUNT ? children.slice(1, SLICE_END) : null;
@@ -12,7 +15,18 @@ export const Breadcrumbs = ({ children, separator = "/" }: BreadcrumbsProps) => 
         clickable={false}
         key="overflow"
       >
-        ...
+        <Popover
+          content={
+            <div className="rounded-lg bg-white p-2 shadow-04">
+              <ul className={clsx("flex flex-col gap-2", "[&>li]:p-2")}>
+                {overflowItems.map((child) => child)}
+              </ul>
+            </div>
+          }
+          position={"bottom"}
+        >
+          {OVERFLOW_TEXT}
+        </Popover>
       </BreadcrumbItem>
     ) : null;
   };

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,7 @@
+import { clsx } from 'clsx';
+
+import type { BreadcrumbsProps } from './type';
+
+export const Breadcrumbs = ({}: BreadcrumbsProps) => {
+  return <></>;
+}

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
@@ -17,10 +17,14 @@ export const Breadcrumbs = ({
   overflowText = DEFAULTS.OVERFLOW_TEXT,
   sliceEnd = DEFAULTS.SLICE_END,
   disableOverflow = false,
+  id,
 }: BreadcrumbsProps) => {
   if (disableOverflow)
     return (
-      <ol className="flex gap-2">
+      <ol
+        className="flex gap-2"
+        id={id}
+      >
         {children
           .map((child, index) => [
             child,
@@ -39,6 +43,7 @@ export const Breadcrumbs = ({
         key="overflow"
       >
         <Popover
+          id={id ? `${id}-overflow` : undefined}
           content={
             <div className="rounded-lg bg-white p-2 shadow-04">
               <ul className={clsx("flex flex-col gap-2", "[&>li]:p-2")}>
@@ -71,5 +76,12 @@ export const Breadcrumbs = ({
     .flat()
     .slice(0, -1);
 
-  return <ol className="flex gap-2">{items}</ol>;
+  return (
+    <ol
+      id={id}
+      className="flex gap-2"
+    >
+      {items}
+    </ol>
+  );
 };

--- a/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/molecules/Breadcrumbs/Breadcrumbs.tsx
@@ -1,7 +1,31 @@
-import { clsx } from 'clsx';
+import { BreadcrumbItem } from "@components/atoms/BreadcrumbItem";
+import type { BreadcrumbsProps } from "./type";
 
-import type { BreadcrumbsProps } from './type';
+const OVERFLOW_COUNT = 4 as const;
+const SLICE_END = -2 as const;
 
-export const Breadcrumbs = ({}: BreadcrumbsProps) => {
-  return <></>;
-}
+export const Breadcrumbs = ({ children, separator = "/" }: BreadcrumbsProps) => {
+  const overflowItems = children.length >= OVERFLOW_COUNT ? children.slice(1, SLICE_END) : null;
+  const el = () => {
+    return overflowItems != null ? (
+      <BreadcrumbItem
+        clickable={false}
+        key="overflow"
+      >
+        ...
+      </BreadcrumbItem>
+    ) : null;
+  };
+  const beforeItem = children[0];
+  const afterItems = children.slice(SLICE_END);
+
+  const items = [beforeItem, el(), ...afterItems]
+    .map((child, index) => [
+      child,
+      <BreadcrumbItem key={`breadcrumbsItem-${index}-separator`}>{separator}</BreadcrumbItem>,
+    ])
+    .flat()
+    .slice(0, -1);
+
+  return <ol className="flex gap-2">{items}</ol>;
+};

--- a/src/components/molecules/Breadcrumbs/const.ts
+++ b/src/components/molecules/Breadcrumbs/const.ts
@@ -1,0 +1,6 @@
+export const DEFAULTS = {
+  OVERFLOW_COUNT: 4,
+  SLICE_END: -2,
+  OVERFLOW_TEXT: "...",
+  SEPARATOR: "/",
+} as const;

--- a/src/components/molecules/Breadcrumbs/index.ts
+++ b/src/components/molecules/Breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export * from './Breadcrumbs';

--- a/src/components/molecules/Breadcrumbs/type.ts
+++ b/src/components/molecules/Breadcrumbs/type.ts
@@ -4,4 +4,9 @@ import { BreadcrumbItemProps } from "@components/atoms/BreadcrumbItem/type";
 export type BreadcrumbsProps = {
   children: ReactElement<BreadcrumbItemProps>[];
   separator?: ReactNode;
+  disableOverflow?: boolean;
+  enableOverflow?: boolean;
+  overflowCount?: number;
+  overflowText?: string;
+  sliceEnd?: number;
 };

--- a/src/components/molecules/Breadcrumbs/type.ts
+++ b/src/components/molecules/Breadcrumbs/type.ts
@@ -1,2 +1,7 @@
+import { ReactElement, ReactNode } from "react";
+import { BreadcrumbItemProps } from "@components/atoms/BreadcrumbItem/type";
+
 export type BreadcrumbsProps = {
-}
+  children: ReactElement<BreadcrumbItemProps>[];
+  separator?: ReactNode;
+};

--- a/src/components/molecules/Breadcrumbs/type.ts
+++ b/src/components/molecules/Breadcrumbs/type.ts
@@ -1,0 +1,2 @@
+export type BreadcrumbsProps = {
+}

--- a/src/components/molecules/Breadcrumbs/type.ts
+++ b/src/components/molecules/Breadcrumbs/type.ts
@@ -9,4 +9,5 @@ export type BreadcrumbsProps = {
   overflowCount?: number;
   overflowText?: string;
   sliceEnd?: number;
+  id?: string;
 };


### PR DESCRIPTION
## 概要 / Overview

新しい`BreadcrumbItem`と`Breadcrumbs`コンポーネントを実装,Storybookを追加した
仕様は[Figma](https://www.figma.com/file/5KaykTqeXvtv3yGH9NV2Ol/Design-System?type=design&node-id=3935-7172&mode=design&t=0RprvFeTO5U9O0Z6-11)を参照 (不明な点があればご質問ください)

### package.jsonのversion

- [x] 上げました

### Figmaのリンク / Figma Link

https://www.figma.com/file/5KaykTqeXvtv3yGH9NV2Ol/Design-System?type=design&node-id=3935-7172&mode=design&t=0RprvFeTO5U9O0Z6-11

## 変更内容 / Changes

- BreadcrumbItemコンポーネントを追加
- Breadcrumbsコンポーネントを追加

## その他 / Other

なし

---

## Overview

Implemented new `BreadcrumbItem` and `Breadcrumbs` components, added Storybook.
Refer to the specification in [Figma](https://www.figma.com/file/5KaykTqeXvtv3yGH9NV2Ol/Design-System?type=design&node-id=3935-7172&mode=design&t=0RprvFeTO5U9O0Z6-11) (please ask if there are any unclear points).

### package.json version

- [ ] Updated

### Figma Link

https://www.figma.com/file/5KaykTqeXvtv3yGH9NV2Ol/Design-System?type=design&node-id=3935-7172&mode=design&t=0RprvFeTO5U9O0Z6-11

## Changes

- Added BreadcrumbItem component
- Added Breadcrumbs component

## Other

None