### PR TITLE
feat: Add `mode` props for Popover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2024-01-11-1",
+  "version": "0.10.2024-01-15-2",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2024-01-15-2",
+  "version": "0.10.2024-01-15-3",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/molecules/Popover/Popover.stories.tsx
+++ b/src/components/molecules/Popover/Popover.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Button } from "@components/atoms";
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -29,24 +30,37 @@ const positions: PopoverProps["position"][] = [
 
 const SampleContent = () => (
   <div className="rounded-lg bg-white p-2 shadow-04">
-    <div className="p-2">Text</div>
-    <div className="p-2">Text</div>
+    <span>Content</span>
   </div>
 );
 
-export const Default: StoryObj<typeof Popover> = {
-  args: {
-    children: (
+const WithStateComponent = (props: PopoverProps) => {
+  const [isOpen, setIsOpen] = useState(props.isOpen);
+
+  return (
+    <Popover
+      {...props}
+      isOpen={isOpen}
+    >
       <Button
         theme="primary"
         size="small"
+        onClick={() => props.mode === "click" && setIsOpen(!isOpen)}
       >
         Button
       </Button>
-    ),
+    </Popover>
+  );
+};
+
+export const Default: StoryObj<typeof Popover> = {
+  args: {
     content: <SampleContent />,
     position: "bottom",
+    mode: "hover",
+    isOpen: false,
   },
+  render: (args) => <WithStateComponent {...args} />,
 };
 
 const SamplePopover = ({ position }: { position: PopoverProps["position"] }) => (

--- a/src/components/molecules/Popover/Popover.stories.tsx
+++ b/src/components/molecules/Popover/Popover.stories.tsx
@@ -45,7 +45,7 @@ const WithStateComponent = (props: PopoverProps) => {
       <Button
         theme="primary"
         size="small"
-        onClick={() => props.mode === "click" && setIsOpen(!isOpen)}
+        onClick={() => props.mode === "click" && setIsOpen((prev) => !prev)}
       >
         Button
       </Button>

--- a/src/components/molecules/Popover/Popover.test.tsx
+++ b/src/components/molecules/Popover/Popover.test.tsx
@@ -7,9 +7,21 @@ import * as PopoverStories from "./Popover.stories";
 const { Default: Popover } = composeStories(PopoverStories);
 
 describe("Popover", () => {
-  test("renders", async () => {
+  test("renders children", async () => {
     render(<Popover />);
     const popoverButton = screen.getByText("Button");
     expect(popoverButton).toBeInTheDocument();
+  });
+  test("show content when isOpen is true", async () => {
+    const { getByRole } = render(<Popover isOpen={true} />);
+    const content = getByRole("dialog");
+
+    expect(content).not.toHaveClass("hidden");
+  });
+  test("not show content when isOpen is false", async () => {
+    const { getByRole } = render(<Popover isOpen={false} />);
+    const content = getByRole("dialog");
+
+    expect(content).toHaveClass("hidden");
   });
 });

--- a/src/components/molecules/Popover/Popover.tsx
+++ b/src/components/molecules/Popover/Popover.tsx
@@ -4,7 +4,14 @@ import { POPOVER_CONTENT_CLASS_NAME, POPOVER_WRAPPER_CLASS_NAME } from "./const"
 import type { PopoverProps } from "./type";
 
 // TODO: HTMLのpopoverで対応したい
-export const Popover = ({ id, children, content, position }: PopoverProps) => {
+export const Popover = ({
+  id,
+  children,
+  content,
+  position,
+  mode = "hover",
+  isOpen = false,
+}: PopoverProps) => {
   return (
     <div className="relative w-fit">
       <div
@@ -15,12 +22,8 @@ export const Popover = ({ id, children, content, position }: PopoverProps) => {
       </div>
 
       <div
-        className={clsx(
-          "absolute z-50 hidden w-max",
-          "hover:flex peer-hover:flex",
-          "focus:flex peer-focus:flex",
-          POPOVER_CONTENT_CLASS_NAME({ position }),
-        )}
+        role="dialog"
+        className={clsx(POPOVER_CONTENT_CLASS_NAME({ position, mode, isOpen }))}
       >
         <div className={POPOVER_WRAPPER_CLASS_NAME({ position })}>{content}</div>
       </div>

--- a/src/components/molecules/Popover/const.ts
+++ b/src/components/molecules/Popover/const.ts
@@ -2,8 +2,16 @@ import clsx from "clsx";
 import { tv } from "tailwind-variants";
 
 export const POPOVER_CONTENT_CLASS_NAME = tv({
-  base: "absolute",
+  base: "absolute z-50 hidden w-max",
   variants: {
+    mode: {
+      hover: clsx("hover:flex peer-hover:flex", "focus:visible peer-focus:visible"),
+      click: clsx(""),
+    },
+    isOpen: {
+      true: clsx("flex"),
+      false: clsx(""),
+    },
     position: {
       bottomRight: clsx("right-0"),
       bottomLeft: clsx("left-0"),

--- a/src/components/molecules/Popover/const.ts
+++ b/src/components/molecules/Popover/const.ts
@@ -6,11 +6,11 @@ export const POPOVER_CONTENT_CLASS_NAME = tv({
   variants: {
     mode: {
       hover: clsx("hover:flex peer-hover:flex", "focus:visible peer-focus:visible"),
-      click: clsx(""),
+      click: "",
     },
     isOpen: {
       true: clsx("flex"),
-      false: clsx(""),
+      false: "",
     },
     position: {
       bottomRight: clsx("right-0"),

--- a/src/components/molecules/Popover/type.ts
+++ b/src/components/molecules/Popover/type.ts
@@ -2,6 +2,8 @@ export type PopoverProps = {
   id?: string;
   children: React.ReactNode;
   content: React.ReactNode;
+  mode?: "click" | "hover";
+  isOpen?: boolean;
   position:
     | "bottom"
     | "bottomLeft"


### PR DESCRIPTION
- feat(Popover):✨Add click mode
- test(Popover):✅Add some tests

## 概要 / Overview

Popoverに`mode`propsを追加しました
これによりPopoverを開く際のトリガー(`click`, `hover`)を選択できるようになりました

### package.jsonのversion

- [ ] 上げました


## 変更内容 / Changes

- Popoverにpropsを追加
  - `mode`: コンテンツを開くトリガーがクリックかホバーか
  - `isOpen`: 開閉状態

## その他 / Other

<!--
  その他困ったこととか伝えたいことを何でも
  Anything else you want to share?
 -->
