### PR TITLE
fix: Selector generic type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2024-01-15-3",
+  "version": "0.10.2024-01-15-4",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/SelectorListItem.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/SelectorListItem.tsx
@@ -1,9 +1,14 @@
 import { CheckIcon } from "@heroicons/react/24/outline";
 import clsx from "clsx";
+import { BaseOptionValue } from "../../type";
 import { LABEL_CLASS_NAME } from "./const";
 import type { SelectorListItemProps } from "./type";
 
-export const SelectorListItem = ({ option, isActive, onClick }: SelectorListItemProps) => {
+export const SelectorListItem = <OptionValue extends BaseOptionValue>({
+  option,
+  isActive,
+  onClick,
+}: SelectorListItemProps<OptionValue>) => {
   return (
     <li
       role="option"

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/type.ts
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/type.ts
@@ -1,8 +1,8 @@
-import { OptionType } from "../../type";
+import { BaseOptionValue, OptionType } from "../../type";
 import { SelectorListProps } from "../type";
 
-export type SelectorListItemProps = {
-  option: OptionType;
+export type SelectorListItemProps<OptionValue extends BaseOptionValue> = {
+  option: OptionType<OptionValue>;
   isActive: boolean;
-  onClick: SelectorListProps["onClick"];
+  onClick: SelectorListProps<OptionValue>["onClick"];
 };

--- a/src/components/molecules/Dialog/Dialog.stories.tsx
+++ b/src/components/molecules/Dialog/Dialog.stories.tsx
@@ -171,10 +171,10 @@ export const ControlledWithSelectorAndInput = () => {
           <Selector
             size="normal"
             options={[
-              { id: 1, label: "Option 1", value: "1" },
-              { id: 2, label: "Option 2", value: "2" },
+              { label: "Option 1", value: "1" },
+              { label: "Option 2", value: "2" },
             ]}
-            defaultLabel="Select an option"
+            placeholder="Select an option"
             onSelect={() => {}}
           />
           <InputText placeholder="Input some text" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -13513,21 +13513,21 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
   version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=1f5320"
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
+  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=1f5320"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
+  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 概要 / Overview

#64の影響でエラーが出ていた箇所を修正しました

```
 > Run yarn build
yarn run v1.22.21
$ tsc && vite build
Error: src/components/atoms/Selector/SelectorList/SelectorListItem/type.ts(5,11): error TS2314: Generic type 'OptionType' requires 1 type argument(s).
Error: src/components/atoms/Selector/SelectorList/SelectorListItem/type.ts(7,12): error TS2314: Generic type 'SelectorListProps' requires 1 type argument(s).
Error: src/components/molecules/Dialog/Dialog.stories.tsx(174,17): error TS2353: Object literal may only specify known properties, and 'id' does not exist in type 'OptionType<BaseOptionValue>'.
Error: src/components/molecules/Dialog/Dialog.stories.tsx(175,17): error TS2353: Object literal may only specify known properties, and 'id' does not exist in type 'OptionType<BaseOptionValue>'.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 2.
```

### package.jsonのversion

- [x] 上げました

### Figmaのリンク / Figma Link

<!--
Figmaの該当箇所のリンクを貼る
Please attach the relevant link from Figma.
-->

### Jira のチケット / Jira Ticket

<!--
Jiraのチケットのリンクを貼る
Link to Jira ticket
 -->

## 変更内容 / Changes

- update yarn.lock
- feat(Selector):🐛Fix selector generic types

<!--
  変更内容を記述する
  Describe your changes here
-->

## その他 / Other

<!--
  その他困ったこととか伝えたいことを何でも
  Anything else you want to share?
 -->
