### PR TITLE
セレクタのアイテムごとにdisabledをかけられるよう修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2024-02-01-1",
+  "version": "0.10.2024-02-05-1",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/Selector/Selector.stories.tsx
+++ b/src/components/atoms/Selector/Selector.stories.tsx
@@ -19,13 +19,14 @@ export const Default: StoryObj<typeof Selector> = {
         value: "option1",
       },
       {
-        label: "オプション2",
+        label: "オプション2(disabled)",
         value: "option2",
+        disabled: true,
       },
       {
-        label: "オプション3(disabled)",
+        label: "オプション3",
         value: "option3",
-        disabled: true,
+        disabled: false,
       },
     ],
   },

--- a/src/components/atoms/Selector/Selector.stories.tsx
+++ b/src/components/atoms/Selector/Selector.stories.tsx
@@ -23,8 +23,9 @@ export const Default: StoryObj<typeof Selector> = {
         value: "option2",
       },
       {
-        label: "オプション3",
+        label: "オプション3(disabled)",
         value: "option3",
+        disabled: true,
       },
     ],
   },
@@ -54,7 +55,7 @@ export const Groups = () => {
             value: "option2",
           },
         ]}
-        value={'option1'}
+        value={"option1"}
         placeholder="選択肢が入ります"
         size="normal"
         disabled={false}

--- a/src/components/atoms/Selector/SelectorList/SelectorList.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorList.tsx
@@ -2,7 +2,11 @@ import { BaseOptionValue } from "../type";
 import { SelectorListItem } from "./SelectorListItem";
 import type { SelectorListProps } from "./type";
 
-export const SelectorList = <OptionValue extends BaseOptionValue>({ options, value, onClick }: SelectorListProps<OptionValue>) => {
+export const SelectorList = <OptionValue extends BaseOptionValue>({
+  options,
+  value,
+  onClick,
+}: SelectorListProps<OptionValue>) => {
   return (
     <ul
       role="listbox"
@@ -13,6 +17,7 @@ export const SelectorList = <OptionValue extends BaseOptionValue>({ options, val
           key={String(option.value)}
           option={option}
           isActive={option.value === value}
+          disabled={option.disabled}
           onClick={onClick}
         />
       ))}

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/SelectorListItem.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/SelectorListItem.tsx
@@ -8,6 +8,7 @@ export const SelectorListItem = <OptionValue extends BaseOptionValue>({
   option,
   isActive,
   onClick,
+  disabled,
 }: SelectorListItemProps<OptionValue>) => {
   return (
     <li
@@ -15,11 +16,13 @@ export const SelectorListItem = <OptionValue extends BaseOptionValue>({
       className={clsx(
         "box-border inline-flex h-10 w-full items-center justify-between truncate rounded-md bg-white px-4",
         "hover:bg-primary-100 hover:text-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600",
+        disabled &&
+          "last:pointer-events-none last:cursor-default last:text-gray-extraDark last:no-underline",
       )}
       onClick={() => onClick(option)}
       tabIndex={0}
     >
-      <span className={LABEL_CLASS_NAME({ isActive })}>{option.label}</span>
+      <span className={LABEL_CLASS_NAME({ isActive, disabled })}>{option.label}</span>
       {isActive && <CheckIcon className="relative h-4 w-4 text-primary-600" />}
     </li>
   );

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/SelectorListItem.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/SelectorListItem.tsx
@@ -8,7 +8,7 @@ export const SelectorListItem = <OptionValue extends BaseOptionValue>({
   option,
   isActive,
   onClick,
-  disabled,
+  disabled = false,
 }: SelectorListItemProps<OptionValue>) => {
   return (
     <li

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/SelectorListItem.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/SelectorListItem.tsx
@@ -16,8 +16,7 @@ export const SelectorListItem = <OptionValue extends BaseOptionValue>({
       className={clsx(
         "box-border inline-flex h-10 w-full items-center justify-between truncate rounded-md bg-white px-4",
         "hover:bg-primary-100 hover:text-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600",
-        disabled &&
-          "last:pointer-events-none last:cursor-default last:text-gray-extraDark last:no-underline",
+        disabled && "pointer-events-none cursor-default text-gray-extraDark no-underline",
       )}
       onClick={() => onClick(option)}
       tabIndex={0}

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/const.ts
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/const.ts
@@ -7,8 +7,12 @@ export const LABEL_CLASS_NAME = tv({
       true: "font-medium",
       false: "font-regular",
     },
+    disabled: {
+      true: "text-gray",
+    },
   },
   defaultVariants: {
     isActive: false,
+    disabled: false,
   },
 });

--- a/src/components/atoms/Selector/SelectorList/SelectorListItem/type.ts
+++ b/src/components/atoms/Selector/SelectorList/SelectorListItem/type.ts
@@ -4,5 +4,6 @@ import { SelectorListProps } from "../type";
 export type SelectorListItemProps<OptionValue extends BaseOptionValue> = {
   option: OptionType<OptionValue>;
   isActive: boolean;
+  disabled?: boolean;
   onClick: SelectorListProps<OptionValue>["onClick"];
 };

--- a/src/components/atoms/Selector/type.ts
+++ b/src/components/atoms/Selector/type.ts
@@ -1,13 +1,14 @@
 type LabelType = string;
 
-export type BaseOptionValue = string | number | boolean
+export type BaseOptionValue = string | number | boolean;
 
 export type OptionType<OptionValue extends BaseOptionValue> = {
   label: LabelType;
   value: OptionValue;
+  disabled?: boolean;
 };
 
-export type SelectorProps<OptionValue extends BaseOptionValue>  = {
+export type SelectorProps<OptionValue extends BaseOptionValue> = {
   size: "small" | "normal";
   options: OptionType<OptionValue>[];
   value?: OptionValue;


### PR DESCRIPTION
## 概要 / Overview

<!--
実装内容のSummaryを記述する
Describe the summary of the implementation
-->

- selectorのoptionsの各アイテムにdisabledを与えることができるよう修正
- disabledなoptionは文字色が薄くなりクリック不可になるよう修正

### package.jsonのversion

- [x] 上げました

### Figmaのリンク / Figma Link
<!--
Figmaの該当箇所のリンクを貼る
Please attach the relevant link from Figma.
-->

- [figma](https://www.figma.com/file/5KaykTqeXvtv3yGH9NV2Ol/Design-System?type=design&node-id=2197-18313&mode=design&t=Ums2yqhuIJxRPRcr-4)

### Jira のチケット / Jira Ticket

<!--
Jiraのチケットのリンクを貼る
Link to Jira ticket
 -->
- チケットはありません。以前モカさんと口頭でやり取りした際の修正依頼のためです

## 変更内容 / Changes

<!--
  変更内容を記述する
  Describe your changes here
-->

## その他 / Other

<!--
  その他困ったこととか伝えたいことを何でも
  Anything else you want to share?
 -->
