### PR TITLE
Fix/button styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2024-02-19-01",
+  "version": "0.10.2024-02-27-01",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/Anchor/Anchor.stories.tsx
+++ b/src/components/atoms/Anchor/Anchor.stories.tsx
@@ -9,10 +9,10 @@ const AnchorSet = ({
   ...props
 }: Pick<
   AnchorProps,
-  "theme" | "isDisabled" | "loading" | "size" | "children" | "background" | "href"
+  "theme" | "isDisabled" | "loading" | "size" | "children" | "variant" | "href"
 >) => {
   return (
-    <div className="flex gap-2">
+    <div className="flex gap-2 items-center">
       <Anchor {...props}>{children}</Anchor>
       <Anchor
         {...props}
@@ -40,12 +40,12 @@ const AnchorSet = ({
 const AnchorSetSection = ({
   title,
   ...props
-}: Pick<AnchorProps, "theme" | "size" | "children" | "background" | "isDisabled" | "href"> & {
+}: Pick<AnchorProps, "theme" | "size" | "children" | "variant" | "isDisabled" | "href"> & {
   title: string;
 }) => (
   <section>
     <h2 className="mb-2">{title}</h2>
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 items-start">
       <AnchorSet {...props} />
       <AnchorSet
         {...props}
@@ -65,10 +65,10 @@ const AnchorSetSection = ({
 );
 
 const ThemeTemplate = (
-  props: Pick<AnchorProps, "children" | "theme" | "onClick" | "background" | "isDisabled" | "href">,
+  props: Pick<AnchorProps, "children" | "theme" | "onClick" | "variant" | "isDisabled" | "href">,
 ) => {
   return (
-    <article className="flex flex-col gap-4">
+    <article className="flex flex-col gap-2 items-start">
       <AnchorSetSection
         title="Small"
         size="small"
@@ -93,14 +93,14 @@ export default {
   argTypes: {
     theme: {
       type: "string",
-      options: ["red", "white", "outline", "gray", "underline"],
+      options: ["red", "gray", "primary"],
       control: {
         type: "select",
       },
     },
-    background: {
+    variant: {
       type: "string",
-      options: ["filled", "white"],
+      options: ["fill", "outline", "text", "underline"],
       control: {
         type: "select",
       },
@@ -116,54 +116,117 @@ export const Default: StoryObj<typeof Anchor> = {
     children: "ボタン",
     theme: "primary",
     size: "small",
+    variant: "fill",
   },
 };
 
-export const Primary = () => (
+export const PrimaryFill = () => (
   <ThemeTemplate
+    variant="fill"
     theme="primary"
-    href="#"
+    href=""
   >
     ボタン
   </ThemeTemplate>
 );
-export const Red = (props: ComponentProps<typeof ThemeTemplate>) => (
+export const RedFill = (props: ComponentProps<typeof ThemeTemplate>) => (
   <ThemeTemplate
     {...props}
     theme="red"
-    href="#"
+    variant="fill"
   >
     ボタン
   </ThemeTemplate>
 );
-export const White = () => (
-  <ThemeTemplate
-    theme="white"
-    href="#"
-  >
-    ボタン
-  </ThemeTemplate>
-);
-export const Gray = (props: ComponentProps<typeof ThemeTemplate>) => (
+export const GrayFill = (props: ComponentProps<typeof ThemeTemplate>) => (
   <ThemeTemplate
     {...props}
     theme="gray"
+    variant="fill"
   >
     ボタン
   </ThemeTemplate>
 );
-export const NoBackground = () => (
+
+export const PrimaryOutline = () => (
   <ThemeTemplate
-    theme="no-background"
-    href="#"
+    variant="outline"
+    theme="primary"
+    href=""
   >
     ボタン
   </ThemeTemplate>
 );
-export const Underline = () => (
+export const RedOutline = (props: ComponentProps<typeof ThemeTemplate>) => (
   <ThemeTemplate
-    theme="underline"
-    href="#"
+    {...props}
+    theme="red"
+    variant="outline"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+export const GrayOutline = (props: ComponentProps<typeof ThemeTemplate>) => (
+  <ThemeTemplate
+    {...props}
+    theme="gray"
+    variant="outline"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+
+export const PrimaryText = () => (
+  <ThemeTemplate
+    variant="text"
+    theme="primary"
+    href=""
+  >
+    ボタン
+  </ThemeTemplate>
+);
+export const RedText = (props: ComponentProps<typeof ThemeTemplate>) => (
+  <ThemeTemplate
+    {...props}
+    theme="red"
+    variant="text"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+export const GrayText = (props: ComponentProps<typeof ThemeTemplate>) => (
+  <ThemeTemplate
+    {...props}
+    theme="gray"
+    variant="text"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+
+export const PrimaryUnderline = () => (
+  <ThemeTemplate
+    variant="underline"
+    theme="primary"
+    href=""
+  >
+    ボタン
+  </ThemeTemplate>
+);
+export const RedUnderline = (props: ComponentProps<typeof ThemeTemplate>) => (
+  <ThemeTemplate
+    {...props}
+    theme="red"
+    variant="underline"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+export const GrayUnderline = (props: ComponentProps<typeof ThemeTemplate>) => (
+  <ThemeTemplate
+    {...props}
+    theme="gray"
+    variant="underline"
   >
     ボタン
   </ThemeTemplate>

--- a/src/components/atoms/Anchor/Anchor.tsx
+++ b/src/components/atoms/Anchor/Anchor.tsx
@@ -11,7 +11,7 @@ export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(
       icon,
       size,
       theme,
-      background = "filled",
+      variant,
       iconPosition = "left",
       isDisabled = false,
       loading = false,
@@ -20,11 +20,12 @@ export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(
     ref,
   ) => {
     const showIcon = !loading && !!icon;
+    const hasChildren = !!children;
     const spinnerProps = {
       // NOTE: ボタンのサイズが`large`でテキストがない場合はアイコンを大きく表示するため
       size: size === "large" && children ? "medium" : size,
-      theme: theme === "underline" ? "no-background" : theme,
-      background,
+      variant: variant === "underline" ? "text" : variant,
+      theme,
     } as const;
 
     return (
@@ -34,19 +35,15 @@ export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(
           isDisabled,
           theme,
           isLoading: loading,
-          hasChildren: !!children,
+          hasChildren,
           size,
-          background,
+          variant: variant === "underline" ? "text" : variant,
           showIcon,
         })}
         ref={ref}
       >
         {showIcon && iconPosition === "left" && (
-          <span
-            className={ANCHOR_ICON_CLASS_NAME({ hasChildren: !!children, size, theme, background })}
-          >
-            {icon}
-          </span>
+          <span className={ANCHOR_ICON_CLASS_NAME({ hasChildren, size, variant })}>{icon}</span>
         )}
         <Spinner
           {...spinnerProps}
@@ -56,20 +53,14 @@ export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(
           <span
             className={ANCHOR_CHILDREN_CLASS_NAME({
               size,
-              theme,
-              background,
-              isLoading: loading,
+              variant,
             })}
           >
             {loading ? "読み込み中..." : children}
           </span>
         )}
         {showIcon && iconPosition === "right" && (
-          <span
-            className={ANCHOR_ICON_CLASS_NAME({ hasChildren: !!children, size, theme, background })}
-          >
-            {icon}
-          </span>
+          <span className={ANCHOR_ICON_CLASS_NAME({ hasChildren, size, variant })}>{icon}</span>
         )}
       </a>
     );

--- a/src/components/atoms/Anchor/const.ts
+++ b/src/components/atoms/Anchor/const.ts
@@ -3,7 +3,6 @@ import { tv } from "tailwind-variants";
 import {
   buttonBaseCompoundVariants,
   buttonBaseVariants,
-  buttonChildrenComposedVariants,
   buttonChildrenVariants,
   buttonIconCompoundVariants,
   buttonIconVariants,
@@ -11,17 +10,10 @@ import {
 
 export const ANCHOR_CLASS_NAME = tv({
   base: clsx(
-    "inline-flex cursor-pointer items-center justify-center gap-1 rounded outline-none duration-300 ease-out group",
-    "disabled:opacity-20",
+    "group inline-flex items-center justify-center gap-1 rounded outline-none transition-all duration-300 ease-out",
     "focus-visible:ring-1 focus-visible:ring-primary-600 focus-visible:ring-offset-2",
   ),
-  variants: {
-    ...buttonBaseVariants,
-    isDisabled: {
-      true: "opacity-20 cursor-not-allowed",
-      false: "",
-    },
-  },
+  variants: buttonBaseVariants,
   compoundVariants: buttonBaseCompoundVariants,
 });
 
@@ -34,5 +26,4 @@ export const ANCHOR_ICON_CLASS_NAME = tv({
 export const ANCHOR_CHILDREN_CLASS_NAME = tv({
   base: "",
   variants: buttonChildrenVariants,
-  compoundVariants: buttonChildrenComposedVariants,
 });

--- a/src/components/atoms/Anchor/const.ts
+++ b/src/components/atoms/Anchor/const.ts
@@ -10,7 +10,7 @@ import {
 
 export const ANCHOR_CLASS_NAME = tv({
   base: clsx(
-    "group inline-flex items-center justify-center gap-1 rounded outline-none transition-all duration-300 ease-out",
+    "group inline-flex items-center justify-center gap-1 rounded outline-none transition-all duration-300 ease-out cursor-pointer",
     "focus-visible:ring-1 focus-visible:ring-primary-600 focus-visible:ring-offset-2",
   ),
   variants: buttonBaseVariants,

--- a/src/components/atoms/Anchor/type.ts
+++ b/src/components/atoms/Anchor/type.ts
@@ -1,12 +1,12 @@
 import { ComponentProps, ReactNode } from "react";
 
-type Theme = "white" | "primary" | "red" | "gray" | "no-background" | "underline";
+type Theme = "primary" | "red" | "gray";
 type Size = "small" | "medium" | "large";
-type Background = "filled" | "white";
+type Variant = "fill" | "outline" | "text" | "underline";
 
 export type AnchorProps = Pick<ComponentProps<"a">, "onClick" | "children"> & {
   icon?: ReactNode;
-  background?: Background;
+  variant: Variant;
   theme: Theme;
   size: Size;
   loading?: boolean;

--- a/src/components/atoms/Button/Button.stories.tsx
+++ b/src/components/atoms/Button/Button.stories.tsx
@@ -7,9 +7,9 @@ import { ButtonProps } from "./type";
 const ButtonSet = ({
   children,
   ...props
-}: Pick<ButtonProps, "theme" | "disabled" | "loading" | "size" | "children" | "background">) => {
+}: Pick<ButtonProps, "theme" | "disabled" | "loading" | "size" | "children" | "variant">) => {
   return (
-    <div className="flex gap-2">
+    <div className="flex gap-2 items-center">
       <Button {...props}>{children}</Button>
       <Button
         {...props}
@@ -37,10 +37,10 @@ const ButtonSet = ({
 const ButtonSetSection = ({
   title,
   ...props
-}: Pick<ButtonProps, "theme" | "size" | "children" | "background"> & { title: string }) => (
+}: Pick<ButtonProps, "theme" | "size" | "children" | "variant"> & { title: string }) => (
   <section>
     <h2 className="mb-2">{title}</h2>
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 items-start">
       <ButtonSet {...props} />
       <ButtonSet
         {...props}
@@ -59,11 +59,9 @@ const ButtonSetSection = ({
   </section>
 );
 
-const ThemeTemplate = (
-  props: Pick<ButtonProps, "children" | "theme" | "onClick" | "background">,
-) => {
+const ThemeTemplate = (props: Pick<ButtonProps, "children" | "theme" | "onClick" | "variant">) => {
   return (
-    <article className="flex flex-col gap-4">
+    <article className="flex flex-col gap-4 items-start">
       <ButtonSetSection
         title="Small"
         size="small"
@@ -88,14 +86,14 @@ export default {
   argTypes: {
     theme: {
       type: "string",
-      options: ["red", "white", "outline", "gray"],
+      options: ["red", "gray", "primary"],
       control: {
         type: "select",
       },
     },
-    background: {
+    variant: {
       type: "string",
-      options: ["filled", "white"],
+      options: ["fill", "outline", "text"],
       control: {
         type: "select",
       },
@@ -118,25 +116,88 @@ export const Default: StoryObj<typeof Button> = {
     children: "ボタン",
     theme: "primary",
     size: "small",
+    disabled: false,
+    variant: "fill",
   },
 };
 
-export const Primary = () => <ThemeTemplate theme="primary">ボタン</ThemeTemplate>;
-export const Red = (props: ComponentProps<typeof ThemeTemplate>) => (
+export const PrimaryFill = () => (
+  <ThemeTemplate
+    variant="fill"
+    theme="primary"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+export const RedFill = (props: ComponentProps<typeof ThemeTemplate>) => (
   <ThemeTemplate
     {...props}
     theme="red"
+    variant="fill"
   >
     ボタン
   </ThemeTemplate>
 );
-export const White = () => <ThemeTemplate theme="white">ボタン</ThemeTemplate>;
-export const Gray = (props: ComponentProps<typeof ThemeTemplate>) => (
+export const GrayFill = (props: ComponentProps<typeof ThemeTemplate>) => (
   <ThemeTemplate
     {...props}
     theme="gray"
+    variant="fill"
   >
     ボタン
   </ThemeTemplate>
 );
-export const NoBackground = () => <ThemeTemplate theme="no-background">ボタン</ThemeTemplate>;
+
+export const PrimaryOutline = () => (
+  <ThemeTemplate
+    variant="outline"
+    theme="primary"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+export const RedOutline = (props: ComponentProps<typeof ThemeTemplate>) => (
+  <ThemeTemplate
+    {...props}
+    theme="red"
+    variant="outline"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+export const GrayOutline = (props: ComponentProps<typeof ThemeTemplate>) => (
+  <ThemeTemplate
+    {...props}
+    theme="gray"
+    variant="outline"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+
+export const PrimaryText = () => (
+  <ThemeTemplate
+    variant="text"
+    theme="primary"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+export const RedText = (props: ComponentProps<typeof ThemeTemplate>) => (
+  <ThemeTemplate
+    {...props}
+    theme="red"
+    variant="text"
+  >
+    ボタン
+  </ThemeTemplate>
+);
+export const GrayText = (props: ComponentProps<typeof ThemeTemplate>) => (
+  <ThemeTemplate
+    {...props}
+    theme="gray"
+    variant="text"
+  >
+    ボタン
+  </ThemeTemplate>
+);

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -8,18 +8,19 @@ export const Button = ({
   icon,
   size,
   theme,
-  background = "filled",
+  variant,
   iconPosition = "left",
   disabled = false,
   loading = false,
   type = "button",
 }: ButtonProps) => {
   const showIcon = !loading && !!icon;
+  const hasChildren = !!children;
   const spinnerProps = {
     // NOTE: ボタンのサイズが`large`でテキストがない場合はアイコンを大きく表示するため
     size: size === "large" && children ? "medium" : size,
     theme,
-    background,
+    variant,
   } as const;
 
   return (
@@ -29,16 +30,20 @@ export const Button = ({
       className={BUTTON_CLASS_NAME({
         theme,
         isLoading: loading,
-        hasChildren: !!children,
+        hasChildren,
         size,
-        background,
+        variant,
         showIcon,
+        isDisabled: disabled,
       })}
       type={type}
     >
       {showIcon && iconPosition === "left" && (
         <span
-          className={BUTTON_ICON_CLASS_NAME({ hasChildren: !!children, size, theme, background })}
+          className={BUTTON_ICON_CLASS_NAME({
+            hasChildren,
+            size,
+          })}
         >
           {icon}
         </span>
@@ -47,13 +52,10 @@ export const Button = ({
         {...spinnerProps}
         loading={loading}
       />
-      {children && (
+      {hasChildren && (
         <span
           className={BUTTON_CHILDREN_CLASS_NAME({
             size,
-            theme,
-            background,
-            isLoading: loading,
           })}
         >
           {loading ? "読み込み中..." : children}
@@ -61,7 +63,10 @@ export const Button = ({
       )}
       {showIcon && iconPosition === "right" && (
         <span
-          className={BUTTON_ICON_CLASS_NAME({ hasChildren: !!children, size, theme, background })}
+          className={BUTTON_ICON_CLASS_NAME({
+            hasChildren,
+            size,
+          })}
         >
           {icon}
         </span>

--- a/src/components/atoms/Button/const.ts
+++ b/src/components/atoms/Button/const.ts
@@ -2,7 +2,6 @@ import clsx from "clsx";
 import { tv } from "tailwind-variants";
 import {
   buttonBaseVariants,
-  buttonChildrenComposedVariants,
   buttonChildrenVariants,
   buttonBaseCompoundVariants,
   buttonIconCompoundVariants,
@@ -11,8 +10,7 @@ import {
 
 export const BUTTON_CLASS_NAME = tv({
   base: clsx(
-    "group inline-flex items-center justify-center gap-1 rounded outline-none duration-300 ease-out",
-    "disabled:opacity-20",
+    "group inline-flex items-center justify-center gap-1 rounded outline-none transition-all duration-300 ease-out",
     "focus-visible:ring-1 focus-visible:ring-primary-600 focus-visible:ring-offset-2",
   ),
   variants: buttonBaseVariants,
@@ -28,5 +26,4 @@ export const BUTTON_ICON_CLASS_NAME = tv({
 export const BUTTON_CHILDREN_CLASS_NAME = tv({
   base: "",
   variants: buttonChildrenVariants,
-  compoundVariants: buttonChildrenComposedVariants,
 });

--- a/src/components/atoms/Button/type.ts
+++ b/src/components/atoms/Button/type.ts
@@ -1,15 +1,15 @@
 import { ComponentProps, ReactNode } from "react";
 
-type Theme = "white" | "primary" | "red" | "gray" | "no-background";
+type Theme = "primary" | "red" | "gray";
 type Size = "small" | "medium" | "large";
-type Background = "filled" | "white";
+type Variant = "fill" | "outline" | "text";
 
 export type ButtonProps = Pick<
   ComponentProps<"button">,
   "onClick" | "disabled" | "children" | "type"
 > & {
   icon?: ReactNode;
-  background?: Background;
+  variant: Variant;
   theme: Theme;
   size: Size;
   loading?: boolean;

--- a/src/components/atoms/DatePicker/DatePicker.stories.tsx
+++ b/src/components/atoms/DatePicker/DatePicker.stories.tsx
@@ -31,14 +31,16 @@ const Dummy = ({ ...args }: Partial<DatePickerProps>) => {
     <div>
       <div className="flex gap-4">
         <Button
-          theme={isOpen ? "primary" : "white"}
+          theme="primary"
+          variant={isOpen ? "fill" : "outline"}
           size="medium"
           onClick={() => setOpen(true)}
         >
           公開日を設定
         </Button>
         <Button
-          theme="white"
+          theme="primary"
+          variant="outline"
           size="medium"
           onClick={() => setOpen(false)}
         >

--- a/src/components/atoms/DatePicker/DatePicker.tsx
+++ b/src/components/atoms/DatePicker/DatePicker.tsx
@@ -132,7 +132,8 @@ export const DatePicker = ({
           {formattedShortcuts.map((shortcut) => (
             <Button
               key={`date-range-picker-shortcut-${shortcut.label}`}
-              theme="white"
+              theme="primary"
+              variant="outline"
               size="small"
               disabled={shortcut.disabled}
               onClick={() => handleSelectShortcut(shortcut.value)}

--- a/src/components/atoms/DatePicker/hooks/useCalendarSlider/useCalendarSlider.stories.tsx
+++ b/src/components/atoms/DatePicker/hooks/useCalendarSlider/useCalendarSlider.stories.tsx
@@ -14,21 +14,24 @@ const Dummy = ({ ...props }: UseCalendarSliderProps) => {
     <div>
       <div className="mb-4 flex gap-2">
         <Button
-          theme="white"
+          theme="primary"
+          variant="outline"
           size="medium"
           onClick={() => slidePrev()}
         >
           前のページ
         </Button>
         <Button
-          theme="white"
+          theme="primary"
+          variant="outline"
           size="medium"
           onClick={() => slideNext()}
         >
           次のページ
         </Button>
         <Button
-          theme="white"
+          theme="primary"
+          variant="outline"
           size="medium"
           onClick={() => skipTo(new Date())}
         >

--- a/src/components/atoms/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/components/atoms/DateRangePicker/DateRangePicker.stories.tsx
@@ -41,7 +41,8 @@ const Dummy = ({ ...args }: Partial<DateRangePickerProps>) => {
     <div>
       <div className="flex gap-4">
         <Button
-          theme={changeType === "from" ? "primary" : "white"}
+          theme="primary"
+          variant={changeType === "from" ? "fill" : "outline"}
           size="medium"
           onClick={() => setChangeType("from")}
         >
@@ -50,7 +51,8 @@ const Dummy = ({ ...args }: Partial<DateRangePickerProps>) => {
             : "チェックイン"}
         </Button>
         <Button
-          theme={changeType === "to" ? "primary" : "white"}
+          theme="primary"
+          variant={changeType === "to" ? "fill" : "outline"}
           size="medium"
           onClick={() => setChangeType("to")}
         >
@@ -59,7 +61,8 @@ const Dummy = ({ ...args }: Partial<DateRangePickerProps>) => {
             : "チェックアウト"}
         </Button>
         <Button
-          theme="white"
+          theme="primary"
+          variant="outline"
           size="medium"
           onClick={() => setChangeType(null)}
         >

--- a/src/components/atoms/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/atoms/DateRangePicker/DateRangePicker.tsx
@@ -138,7 +138,8 @@ export const DateRangePicker = ({
           {formattedShortcuts.map((shortcut) => (
             <Button
               key={`date-range-picker-shortcut-${shortcut.label}`}
-              theme="white"
+              theme="primary"
+              variant="outline"
               size="small"
               disabled={shortcut.disabled}
               onClick={() => handleSelectShortcut(shortcut.value)}

--- a/src/components/atoms/Spinner/Spinner.tsx
+++ b/src/components/atoms/Spinner/Spinner.tsx
@@ -1,7 +1,7 @@
 import { SPINNER_CLASS_NAME } from "./const";
 import type { SpinnerProps } from "./type";
 
-export const Spinner = ({ size, theme, loading, background }: SpinnerProps) => {
+export const Spinner = ({ size, theme, loading, variant }: SpinnerProps) => {
   if (!loading) return null;
   return (
     <span
@@ -11,7 +11,7 @@ export const Spinner = ({ size, theme, loading, background }: SpinnerProps) => {
     >
       <svg
         aria-hidden="true"
-        className={SPINNER_CLASS_NAME({ theme, size, background })}
+        className={SPINNER_CLASS_NAME({ theme, size, variant })}
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/atoms/Spinner/const.ts
+++ b/src/components/atoms/Spinner/const.ts
@@ -1,11 +1,12 @@
 import { tv } from "tailwind-variants";
 
 export const SPINNER_CLASS_NAME = tv({
-  base: "animate-spin  text-opacity-20",
+  base: "animate-spin text-opacity-20",
   variants: {
-    background: {
-      filled: "",
-      white: "",
+    variant: {
+      fill: "",
+      outline: "",
+      text: "",
     },
     size: {
       small: "h-3 w-3",
@@ -13,33 +14,56 @@ export const SPINNER_CLASS_NAME = tv({
       large: "h-6 w-6",
     },
     theme: {
-      white: "fill-primary-600 text-gray",
-      primary: "fill-white text-primary-800",
+      primary: "",
+      red: "",
       gray: "",
-      red: "fill-white text-red-dark",
-      "no-background": "fill-primary-600 text-gray",
     },
   },
   compoundVariants: [
     {
-      background: "filled",
-      theme: "gray",
-      class: "fill-white text-black",
+      theme: "primary",
+      variant: "fill",
+      class: "fill-white text-primary-800",
     },
     {
-      background: "white",
-      theme: "gray",
-      class: "fill-black text-gray",
-    },
-    {
-      background: "filled",
       theme: "red",
+      variant: "fill",
       class: "fill-white text-red-dark",
     },
     {
-      background: "white",
+      theme: "gray",
+      variant: "fill",
+      class: "fill-white text-black",
+    },
+    {
+      theme: "primary",
+      variant: "outline",
+      class: "fill-primary-600 text-gray",
+    },
+    {
       theme: "red",
+      variant: "outline",
       class: "fill-red text-gray",
+    },
+    {
+      theme: "gray",
+      variant: "outline",
+      class: "fill-black text-gray",
+    },
+    {
+      theme: "primary",
+      variant: "text",
+      class: "fill-primary-600 text-gray",
+    },
+    {
+      theme: "red",
+      variant: "text",
+      class: "fill-red text-gray",
+    },
+    {
+      theme: "gray",
+      variant: "text",
+      class: "fill-black text-gray",
     },
   ],
 });

--- a/src/components/atoms/Spinner/type.ts
+++ b/src/components/atoms/Spinner/type.ts
@@ -1,6 +1,6 @@
 export type SpinnerProps = {
   size: "small" | "medium" | "large";
-  theme: "primary" | "white" | "gray" | "red" | "no-background";
-  background?: "filled" | "white";
+  theme: "primary" | "red" | "gray";
+  variant: "fill" | "outline" | "text";
   loading: boolean;
 };

--- a/src/components/atoms/Tooltip/Tooltip.stories.tsx
+++ b/src/components/atoms/Tooltip/Tooltip.stories.tsx
@@ -52,7 +52,8 @@ export const WithButton: StoryObj<typeof Tooltip> = {
     alignment: "center",
     children: (
       <Button
-        theme="white"
+        theme="primary"
+        variant="outline"
         size="medium"
       >
         Test

--- a/src/components/molecules/Dialog/Dialog.stories.tsx
+++ b/src/components/molecules/Dialog/Dialog.stories.tsx
@@ -69,6 +69,7 @@ export const Controlled = () => {
     <>
       <Button
         theme="primary"
+        variant="fill"
         size="medium"
         onClick={() => setIsOpen(true)}
       >
@@ -97,6 +98,7 @@ export const ControlledWithScroll = () => {
     <>
       <Button
         theme="primary"
+        variant="fill"
         size="medium"
         onClick={() => setIsOpen(true)}
       >
@@ -157,6 +159,7 @@ export const ControlledWithSelectorAndInput = () => {
     <>
       <Button
         theme="primary"
+        variant="fill"
         size="medium"
         onClick={() => setIsOpen(true)}
       >
@@ -192,6 +195,7 @@ export const ControlledWithButton = () => {
     <>
       <Button
         theme="primary"
+        variant="fill"
         size="medium"
         onClick={() => setIsOpen(true)}
       >
@@ -241,15 +245,16 @@ export const ControlledWithButton = () => {
         </div>
         <div className="flex items-center justify-end gap-2 border-t border-t-gray-light px-10 py-4">
           <Button
-            theme={"white"}
-            background="white"
+            theme="primary"
+            variant="outline"
             size="medium"
             onClick={() => setIsOpen(false)}
           >
             キャンセル
           </Button>
           <Button
-            theme={"primary"}
+            theme="primary"
+            variant="fill"
             size="medium"
             onClick={() => console.log("save")}
           >

--- a/src/components/molecules/Popover/Popover.stories.tsx
+++ b/src/components/molecules/Popover/Popover.stories.tsx
@@ -44,6 +44,7 @@ const WithStateComponent = (props: PopoverProps) => {
     >
       <Button
         theme="primary"
+        variant="fill"
         size="small"
         onClick={() => props.mode === "click" && setIsOpen((prev) => !prev)}
       >
@@ -70,7 +71,8 @@ const SamplePopover = ({ position }: { position: PopoverProps["position"] }) => 
     position={position}
   >
     <Button
-      theme={"primary"}
+      theme="primary"
+      variant="fill"
       size={"small"}
     >
       {position}

--- a/src/components/molecules/RichMenuDescription/RichMenuDescription.tsx
+++ b/src/components/molecules/RichMenuDescription/RichMenuDescription.tsx
@@ -24,7 +24,8 @@ export const RichMenuDescription = ({
       <div className="mt-4 w-fit self-center">
         <Anchor
           href={faqLink}
-          theme="no-background"
+          theme="primary"
+          variant="text"
           size="small"
           iconPosition="right"
           icon={<ArrowTopRightOnSquareIcon />}

--- a/src/components/molecules/RichMenuList/RichMenuList.stories.tsx
+++ b/src/components/molecules/RichMenuList/RichMenuList.stories.tsx
@@ -43,7 +43,8 @@ export const Default: StoryObj<typeof RichMenuList> = {
         items: [...Array(10)].map(() => commonItems),
         bottomButton: (
           <Button
-            theme="no-background"
+            theme="primary"
+            variant="text"
             size="small"
             iconPosition="right"
             icon={<ChevronRightIcon />}

--- a/src/components/molecules/RichMenuList/RichMenuList.tsx
+++ b/src/components/molecules/RichMenuList/RichMenuList.tsx
@@ -32,7 +32,8 @@ export const RichMenuList = ({ groups, onViewAllFolders }: RichMenuListProps) =>
       </div>
       <div className="w-fit self-center">
         <Button
-          theme="no-background"
+          theme="primary"
+          variant="text"
           size="small"
           iconPosition="right"
           icon={<ChevronRightIcon />}

--- a/src/components/organisms/RichMenu/RichMenu.stories.tsx
+++ b/src/components/organisms/RichMenu/RichMenu.stories.tsx
@@ -64,7 +64,8 @@ export const Default: StoryObj<typeof RichMenu> = {
         items: [...Array(10)].map(() => commonItems),
         bottomButton: (
           <Button
-            theme="no-background"
+            theme="primary"
+            variant="text"
             size="small"
             iconPosition="right"
             icon={<ChevronRightIcon />}

--- a/src/theme/buttonTheme/compoundVariants.ts
+++ b/src/theme/buttonTheme/compoundVariants.ts
@@ -1,14 +1,10 @@
 import { ComponentVariants } from "./type";
-import { buttonBaseVariants, buttonChildrenVariants, buttonIconVariants } from "./variants";
+import { buttonBaseVariants, buttonIconVariants } from "./variants";
 
 export const buttonBaseCompoundVariants: ComponentVariants<typeof buttonBaseVariants>[] = [
   {
-    theme: "white",
-    isLoading: true,
-    class: "text-black",
-  },
-  {
     showIcon: true,
+    isLoading: false,
     size: "medium",
     class: "p-2",
   },
@@ -28,42 +24,129 @@ export const buttonBaseCompoundVariants: ComponentVariants<typeof buttonBaseVari
     class: "p-2",
   },
   {
-    theme: "no-background",
+    showIcon: true,
+    isLoading: false,
+    variant: "text",
+    size: "medium",
     class: "px-1 py-0.5",
   },
   {
-    theme: "gray",
-    background: "filled",
-    isLoading: true,
-    class: "bg-gray-extraDark",
+    hasChildren: false,
+    variant: "text",
+    class: "px-1 py-0.5",
   },
   {
-    theme: "gray",
-    background: "filled",
+    theme: "red",
+    variant: "fill",
+    class: "shadow-01 bg-red text-white",
+  },
+  {
+    theme: "red",
+    variant: "fill",
+    isDisabled: false,
     isLoading: false,
-    class: "bg-black hover:bg-gray-extraDark",
+    class: "hover:bg-red-dark active:bg-red-dark",
+  },
+  {
+    theme: "primary",
+    variant: "fill",
+    class: "bg-primary-600 shadow-01 text-white",
+  },
+  {
+    theme: "primary",
+    variant: "fill",
+    isDisabled: false,
+    isLoading: false,
+    class: "hover:bg-primary-700 active:bg-primary-900",
   },
   {
     theme: "gray",
-    background: "white",
-    class: "border-px border-gray-light bg-white hover:bg-gray-extraLight active:bg-gray-light",
+    variant: "fill",
+    class: "shadow-01 bg-gray-extraDark text-white",
   },
   {
-    theme: "red",
-    background: "filled",
-    isLoading: true,
-    class: "bg-red",
-  },
-  {
-    theme: "red",
-    background: "filled",
+    theme: "gray",
+    variant: "fill",
+    isDisabled: false,
     isLoading: false,
-    class: "bg-red hover:bg-red-dark active:bg-red-dark",
+    class: "hover:bg-black",
   },
   {
     theme: "red",
-    background: "white",
-    class: "border border-red hover:bg-red-light active:border-red-dark",
+    variant: "outline",
+    class: "border border-red text-red shadow-01",
+  },
+  {
+    theme: "red",
+    variant: "outline",
+    isDisabled: false,
+    isLoading: false,
+    class: "hover:bg-red-light active:border-red-dark active:text-red-dark",
+  },
+  {
+    theme: "primary",
+    variant: "outline",
+    class: "border border-primary-400 bg-white shadow-01 text-primary-600",
+  },
+  {
+    theme: "primary",
+    variant: "outline",
+    isDisabled: false,
+    isLoading: false,
+    class: "hover:bg-primary-100 active:bg-primary-300",
+  },
+  {
+    theme: "gray",
+    variant: "outline",
+    class: "border border-gray-light bg-white shadow-01 text-gray-extraDark",
+  },
+  {
+    theme: "gray",
+    variant: "outline",
+    isDisabled: false,
+    isLoading: false,
+    class: "hover:bg-gray-extraLight active:bg-gray-light",
+  },
+  {
+    variant: "outline",
+    isLoading: true,
+    class: "text-black",
+  },
+  {
+    theme: "red",
+    variant: "text",
+    class: "text-red",
+  },
+  {
+    theme: "red",
+    variant: "text",
+    isDisabled: false,
+    isLoading: false,
+    class: "hover:bg-red-light active:text-red-dark",
+  },
+  {
+    theme: "primary",
+    variant: "text",
+    class: "text-primary-600",
+  },
+  {
+    theme: "primary",
+    variant: "text",
+    isDisabled: false,
+    isLoading: false,
+    class: "hover:bg-gray-extraLight active:text-primary-900",
+  },
+  {
+    theme: "gray",
+    variant: "text",
+    class: "text-gray-extraDark",
+  },
+  {
+    theme: "gray",
+    variant: "text",
+    isDisabled: false,
+    isLoading: false,
+    class: "hover:bg-gray-extraLight active:text-black",
   },
 ];
 
@@ -72,55 +155,5 @@ export const buttonIconCompoundVariants: ComponentVariants<typeof buttonIconVari
     size: "large",
     hasChildren: true,
     class: "h-4 w-4",
-  },
-  {
-    background: "filled",
-    theme: "gray",
-    class: "text-white",
-  },
-  {
-    background: "white",
-    theme: "gray",
-    class: "text-black",
-  },
-  {
-    background: "filled",
-    theme: "red",
-    class: "text-white",
-  },
-  {
-    background: "white",
-    theme: "red",
-    class: "text-red group-active:text-red-dark",
-  },
-];
-
-export const buttonChildrenComposedVariants: ComponentVariants<typeof buttonChildrenVariants>[] = [
-  {
-    background: "filled",
-    theme: "gray",
-    class: "text-white",
-  },
-  {
-    background: "white",
-    theme: "gray",
-    class: "text-gray-extraDark",
-  },
-  {
-    isLoading: false,
-    background: "white",
-    theme: "red",
-    class: "text-red group-active:text-red-dark active:text-red-dark",
-  },
-  {
-    isLoading: true,
-    background: "white",
-    theme: "red",
-    class: "text-black",
-  },
-  {
-    background: "filled",
-    theme: "red",
-    class: "text-white",
   },
 ];

--- a/src/theme/buttonTheme/variants.ts
+++ b/src/theme/buttonTheme/variants.ts
@@ -1,50 +1,39 @@
 export const buttonBaseVariants = {
-  showIcon: {
-    true: "",
-    false: "",
-  },
-  isLoading: {
-    true: "",
-    false: "",
-  },
-  background: {
-    filled: "",
-    white: "",
-  },
-  hasChildren: {
-    true: "text-center font-medium leading-none",
-    false: "",
-  },
   theme: {
-    white:
-      "border border-primary-400 bg-white shadow-01 hover:bg-primary-100 active:bg-primary-300",
-    primary: "bg-primary-600 shadow-01 hover:bg-primary-700 active:bg-primary-900",
-    "no-background": "hover:bg-gray-extraLight",
-    red: "shadow-01",
-    gray: "shadow-01",
-    underline: "hover:bg-gray-extraLight",
+    red: "",
+    primary: "",
+    gray: "",
   },
   size: {
     small: "px-2 py-1.5",
     medium: "px-4 py-2",
     large: "px-4 py-3",
   },
+  isLoading: {
+    true: "cursor-not-allowed",
+    false: "",
+  },
+  isDisabled: {
+    true: "opacity-20 cursor-not-allowed",
+    false: "",
+  },
+  hasChildren: {
+    true: "text-center font-medium leading-none",
+    false: "",
+  },
+  variant: {
+    fill: "",
+    outline: "",
+    text: "px-1 py-0.5",
+    underline: "",
+  },
+  showIcon: {
+    true: "",
+    false: "",
+  },
 };
 
 export const buttonIconVariants = {
-  background: {
-    filled: "",
-    white: "",
-  },
-  theme: {
-    white: "text-primary-600",
-    primary: "text-gray-light",
-    "no-background": "text-primary-600",
-    red: "",
-    gray: "",
-    underline:
-      "text-primary-600 underline underline-primary-600 active:text-primary-900 active:underline-primary-900",
-  },
   size: {
     small: "h-3 w-3",
     medium: "h-4 w-4",
@@ -54,29 +43,24 @@ export const buttonIconVariants = {
     true: "",
     false: "",
   },
+  variant: {
+    fill: "",
+    outline: "",
+    text: "",
+    underline: "underline",
+  },
 };
 
 export const buttonChildrenVariants = {
-  isLoading: {
-    true: "",
-    false: "",
-  },
-  background: {
-    filled: "",
-    white: "",
-  },
-  theme: {
-    white: "text-primary-600",
-    primary: "text-white",
-    "no-background": "text-primary-600 active:text-primary-900",
-    red: "",
-    gray: "",
-    underline:
-      "text-primary-600 underline underline-primary-600 active:text-primary-900 active:underline-primary-900",
-  },
   size: {
-    small: "text-xs",
-    medium: "text-sm",
+    small: "text-xs leading-3",
+    medium: "text-s",
     large: "text-base",
+  },
+  variant: {
+    fill: "",
+    outline: "",
+    text: "",
+    underline: "underline",
   },
 };


### PR DESCRIPTION
## 概要 / Overview

- Changed the `theme` and `background` props for a smoother usage of components
    - `background` is now called `variant`
- Implemented all styles from Figma

_日本語_:
- テーマ」と「背景」のプロップを変更し、コンポーネントをよりスムーズに使用できるようにした。
   - background`は現在`variant`と呼ばれている。
- Figmaのスタイルをすべて実装

### package.jsonのversion

- [ ] 上げました

### Figmaのリンク / Figma Link

https://www.figma.com/file/5KaykTqeXvtv3yGH9NV2Ol/Design-System?type=design&node-id=2188-14727&mode=design&t=zrpJkP6fbsyNqaLi-0

## 変更内容 / Changes

There are breaking changes with this PullRequest. Step two of this change would be to merge the changes, update the package in squadbeyond-frontend and update every `Button` and `Anchor`.

このPullRequestには変更点があります。この変更のステップ2は、変更をマージし、squadbeyond-frontendのパッケージを更新し、すべての`ボタン`と`アンカー`を更新することです。
