### PR TITLE
fix(Tooltip):💄 Fix tooltip width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2024-03-11-01",
+  "version": "0.10.2024-03-14-01",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/Tooltip/Tooltip.tsx
+++ b/src/components/atoms/Tooltip/Tooltip.tsx
@@ -64,7 +64,7 @@ export const Tooltip = ({
             id={ariaLabelledBy}
             aria-hidden={!isOpen}
             ref={tooltipRef}
-            className="absolute z-40 inline-block w-40 rounded bg-white text-sm leading-normal drop-shadow-md"
+            className="absolute z-40 inline-block rounded bg-white text-sm leading-normal drop-shadow-md"
             style={tooltipPositionStyles}
           >
             <span className="relative inline-flex h-full w-full items-center justify-center p-2">


### PR DESCRIPTION
## 概要 / Overview

ツールチップ内のテキストが画像のようにはみ出てしまう問題を修正しました
I fixed the issue where the text inside the tooltip overflows as shown in the image.

![スクリーンショット 2024-03-06 14 49 59](https://github.com/siva-squad/squad-ui/assets/19528768/9fe67bfd-3331-466c-972d-be98603d1713)

### package.jsonのversion

- [x] 上げました

## 変更内容 / Changes

ツールチップテキストを表示する枠のwidth指定を削除した
I removed the width specification for the frame displaying the tooltip text.

![スクリーンショット 2024-03-06 14 49 49](https://github.com/siva-squad/squad-ui/assets/19528768/be97cbcb-2d7f-4a2f-b342-82d5e1d6bbe5)

## その他 / Other

<!--
  その他困ったこととか伝えたいことを何でも
  Anything else you want to share?
 -->
