### PR TITLE
feat:Change the selector to use react-portal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2024-03-14-01",
+  "version": "0.10.2024-03-14-02",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/Selector/Selector.stories.tsx
+++ b/src/components/atoms/Selector/Selector.stories.tsx
@@ -13,22 +13,10 @@ export const Default: StoryObj<typeof Selector> = {
     disabled: false,
     size: "normal",
     placeholder: "選択肢が入ります",
-    options: [
-      {
-        label: "オプション1",
-        value: "option1",
-      },
-      {
-        label: "オプション2(disabled)",
-        value: "option2",
-        disabled: true,
-      },
-      {
-        label: "オプション3",
-        value: "option3",
-        disabled: false,
-      },
-    ],
+    options: new Array(10).fill(null).map((_, index) => ({
+      label: `オプション_${index}`,
+      value: `option_${index}`,
+    })),
   },
 };
 

--- a/src/components/atoms/Selector/Selector.tsx
+++ b/src/components/atoms/Selector/Selector.tsx
@@ -11,10 +11,21 @@ import { SelectorList } from "./SelectorList";
 
 import type { BaseOptionValue, OptionType, SelectorProps } from "./type";
 
-export const Selector = <OptionValue extends BaseOptionValue>({ size, options, value, placeholder, disabled, onSelect }: SelectorProps<OptionValue>) => {
+export const Selector = <OptionValue extends BaseOptionValue>({
+  size,
+  options,
+  value,
+  placeholder,
+  disabled,
+  onSelect,
+  listHeight,
+}: SelectorProps<OptionValue>) => {
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef(null);
-  const activeLabel = useMemo(() => options.find(option => option.value === value)?.label ?? placeholder, [options, value, placeholder]);
+  const activeLabel = useMemo(
+    () => options.find((option) => option.value === value)?.label ?? placeholder,
+    [options, value, placeholder],
+  );
 
   useOutsideClick(wrapperRef, () => setIsOpen(false));
 
@@ -47,6 +58,7 @@ export const Selector = <OptionValue extends BaseOptionValue>({ size, options, v
       </button>
       {isOpen && (
         <SelectorList
+          listHeight={listHeight}
           options={options}
           value={value}
           onClick={onClick}

--- a/src/components/atoms/Selector/Selector.tsx
+++ b/src/components/atoms/Selector/Selector.tsx
@@ -25,6 +25,7 @@ export const Selector = <OptionValue extends BaseOptionValue>({ size, options, v
 
   const onClick = (option: OptionType<OptionValue>) => {
     onSelect(option.value);
+    setIsOpen(false);
   };
 
   return (

--- a/src/components/atoms/Selector/Selector.tsx
+++ b/src/components/atoms/Selector/Selector.tsx
@@ -62,6 +62,7 @@ export const Selector = <OptionValue extends BaseOptionValue>({
           options={options}
           value={value}
           onClick={onClick}
+          parentRef={wrapperRef}
         />
       )}
     </div>

--- a/src/components/atoms/Selector/SelectorList/SelectorList.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorList.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { BaseOptionValue } from "../type";
 import { SelectorListItem } from "./SelectorListItem";
 import type { SelectorListProps } from "./type";
@@ -7,8 +9,26 @@ export const SelectorList = <OptionValue extends BaseOptionValue>({
   value,
   onClick,
   listHeight,
+  parentRef,
 }: SelectorListProps<OptionValue>) => {
-  return (
+  const ref = useRef<HTMLBodyElement | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    ref.current = document.querySelector("body");
+    setMounted(true);
+  }, []);
+
+  if (!mounted || !ref.current || !parentRef.current) {
+    return;
+  }
+
+  const [rect] = parentRef.current.getClientRects();
+  const top = rect.y + rect.height;
+  const left = rect.x;
+  const width = rect.width;
+
+  return createPortal(
     <div
       className="absolute top-0 z-[1] mt-2 flex flex-col items-start justify-start rounded bg-white py-1 shadow-03"
       style={{ maxHeight: listHeight || "13rem", width, top, left }}
@@ -27,6 +47,7 @@ export const SelectorList = <OptionValue extends BaseOptionValue>({
           />
         ))}
       </ul>
-    </div>
+    </div>,
+    ref.current,
   );
 };

--- a/src/components/atoms/Selector/SelectorList/SelectorList.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorList.tsx
@@ -8,19 +8,21 @@ export const SelectorList = <OptionValue extends BaseOptionValue>({
   onClick,
 }: SelectorListProps<OptionValue>) => {
   return (
-    <ul
-      role="listbox"
-      className="z-[1] flex w-full flex-col items-start justify-start rounded bg-white py-1 shadow-03"
-    >
-      {options.map((option) => (
-        <SelectorListItem
-          key={String(option.value)}
-          option={option}
-          isActive={option.value === value}
-          disabled={option.disabled}
-          onClick={onClick}
-        />
-      ))}
-    </ul>
+    <div className="z-[1] flex h-52 w-full flex-col items-start justify-start rounded bg-white py-1 shadow-03">
+      <ul
+        role="listbox"
+        className="hidden-scrollbar w-full overflow-y-scroll"
+      >
+        {options.map((option) => (
+          <SelectorListItem
+            key={String(option.value)}
+            option={option}
+            isActive={option.value === value}
+            disabled={option.disabled}
+            onClick={onClick}
+          />
+        ))}
+      </ul>
+    </div>
   );
 };

--- a/src/components/atoms/Selector/SelectorList/SelectorList.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorList.tsx
@@ -10,7 +10,7 @@ export const SelectorList = <OptionValue extends BaseOptionValue>({
   return (
     <ul
       role="listbox"
-      className="z-[1] flex h-52 w-full flex-col items-start justify-start rounded bg-white py-1 shadow-03"
+      className="z-[1] flex w-full flex-col items-start justify-start rounded bg-white py-1 shadow-03"
     >
       {options.map((option) => (
         <SelectorListItem

--- a/src/components/atoms/Selector/SelectorList/SelectorList.tsx
+++ b/src/components/atoms/Selector/SelectorList/SelectorList.tsx
@@ -6,9 +6,13 @@ export const SelectorList = <OptionValue extends BaseOptionValue>({
   options,
   value,
   onClick,
+  listHeight,
 }: SelectorListProps<OptionValue>) => {
   return (
-    <div className="z-[1] flex h-52 w-full flex-col items-start justify-start rounded bg-white py-1 shadow-03">
+    <div
+      className="absolute top-0 z-[1] mt-2 flex flex-col items-start justify-start rounded bg-white py-1 shadow-03"
+      style={{ maxHeight: listHeight || "13rem", width, top, left }}
+    >
       <ul
         role="listbox"
         className="hidden-scrollbar w-full overflow-y-scroll"

--- a/src/components/atoms/Selector/SelectorList/type.ts
+++ b/src/components/atoms/Selector/SelectorList/type.ts
@@ -2,6 +2,7 @@ import { BaseOptionValue, OptionType } from "../type";
 
 export type SelectorListProps<OptionValue extends BaseOptionValue> = {
   options: OptionType<OptionValue>[];
-  value?: OptionValue
+  value?: OptionValue;
+  listHeight?: number;
   onClick: (option: OptionType<OptionValue>) => void;
 };

--- a/src/components/atoms/Selector/SelectorList/type.ts
+++ b/src/components/atoms/Selector/SelectorList/type.ts
@@ -4,5 +4,6 @@ export type SelectorListProps<OptionValue extends BaseOptionValue> = {
   options: OptionType<OptionValue>[];
   value?: OptionValue;
   listHeight?: number;
+  parentRef: React.RefObject<HTMLDivElement>;
   onClick: (option: OptionType<OptionValue>) => void;
 };

--- a/src/components/atoms/Selector/hooks/useOutsideClick.ts
+++ b/src/components/atoms/Selector/hooks/useOutsideClick.ts
@@ -9,9 +9,9 @@ export const useOutsideClick = (ref: React.RefObject<HTMLElement>, callback: () 
   };
 
   useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("click", handleClickOutside);
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("click", handleClickOutside);
     };
   });
 };

--- a/src/components/atoms/Selector/type.ts
+++ b/src/components/atoms/Selector/type.ts
@@ -14,5 +14,6 @@ export type SelectorProps<OptionValue extends BaseOptionValue> = {
   value?: OptionValue;
   placeholder: LabelType;
   disabled?: boolean;
+  listHeight?: number;
   onSelect: (value: OptionValue) => void;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -13513,21 +13513,21 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
   version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=1f5320"
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
+  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=1f5320"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
+  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 概要 / Overview

Selectorコンポーネントをタイトルの通り変更しました

### 背景

beyondページのフォルダ移動ダイアログでキャプチャのように表示されてしまうため

![image](https://github.com/siva-squad/squad-ui/assets/19528768/63cc3854-1b5e-4c5b-aaa5-99e595086d98)

### package.jsonのversion

- [x] 上げました

## 変更内容 / Changes

- パッケージバージョンを更新
- リストのmaxHeightをpropskで指定できるように変更
  - はみ出た場合はスクロール可能
- 他の要素と重ならないようにrect-portalを使用する形に変更

## その他 / Other

<!--
  その他困ったこととか伝えたいことを何でも
  Anything else you want to share?
 -->
