### PR TITLE
GlobalNavigation: GlobalAccount 操作時の処理を追加できるよう修正

### DIFF
--- a/src/components/molecules/ListItemDropDown/const.ts
+++ b/src/components/molecules/ListItemDropDown/const.ts
@@ -1,28 +1,28 @@
-import { ListItemProps } from "@components/atoms/ListItem/type";
+import { MenuNavigationItemProps } from "../MenuList";
 
-export const OTHERS_NAVIGATION: ListItemProps[] = [
+export const OTHERS_NAVIGATION = [
   {
-    id: "1",
+    id: "faq",
     title: "FAQ",
     href: "",
     hasChevron: false,
   },
   {
-    id: "2",
+    id: "terms",
     title: "利用規約",
     href: "",
     hasChevron: false,
   },
   {
-    id: "3",
+    id: "policy",
     title: "プライバシーポリシー",
     href: "",
     hasChevron: false,
   },
   {
-    id: "4",
+    id: "admin",
     title: "Admin",
     href: "",
     hasChevron: false,
   },
-];
+] satisfies MenuNavigationItemProps[];

--- a/src/components/molecules/MenuList/MenuList.tsx
+++ b/src/components/molecules/MenuList/MenuList.tsx
@@ -7,7 +7,9 @@ import { MenuListProps } from "./type";
 
 export const MenuList = forwardRef<HTMLElement, MenuListProps>(
   ({ navigationType, onMouseEnter, onClick }, ref) => {
-    const [menuNavigationItems] = MENU_NAVIGATION.filter((nav) => nav.groupId === navigationType);
+    const [menuNavigationItems] = MENU_NAVIGATION({ onClick }).filter(
+      (nav) => nav.groupId === navigationType,
+    );
 
     return (
       <nav

--- a/src/components/molecules/MenuList/MenuList.tsx
+++ b/src/components/molecules/MenuList/MenuList.tsx
@@ -6,7 +6,7 @@ import { MENU_NAVIGATION } from "./const";
 import { MenuListProps } from "./type";
 
 export const MenuList = forwardRef<HTMLElement, MenuListProps>(
-  ({ navigationType, onMouseEnter }, ref) => {
+  ({ navigationType, onMouseEnter, onClick }, ref) => {
     const [menuNavigationItems] = MENU_NAVIGATION.filter((nav) => nav.groupId === navigationType);
 
     return (
@@ -18,7 +18,7 @@ export const MenuList = forwardRef<HTMLElement, MenuListProps>(
           if (item.children) {
             return (
               <ListItemDropDown
-                {...(item as ListItemProps)}
+                {...({ ...item, onClick: () => onClick && onClick(item.id) } as ListItemProps)}
                 onMouseEnter={() => onMouseEnter(item.id)}
                 key={item.id}
               >
@@ -29,7 +29,7 @@ export const MenuList = forwardRef<HTMLElement, MenuListProps>(
 
           return (
             <ListItem
-              {...(item as ListItemProps)}
+              {...({ ...item, onClick: () => onClick && onClick(item.id) } as ListItemProps)}
               key={item.id}
               onMouseEnter={() => onMouseEnter(item.id)}
               size="large"

--- a/src/components/molecules/MenuList/const.tsx
+++ b/src/components/molecules/MenuList/const.tsx
@@ -14,8 +14,11 @@ import {
   ShieldCheckIcon as ShieldCheckIconSolid,
   ClipboardDocumentIcon as ClipboardDocumentIconSolid,
 } from "@heroicons/react/24/solid";
-import type { MenuNavigationType } from "@molecules/MenuList";
-import { OTHERS_NAVIGATION } from "../ListItemDropDown/const";
+import type {
+  MenuListProps,
+  MenuNavigationItemProps,
+  MenuNavigationType,
+} from "@molecules/MenuList";
 
 export const MENU_NAVIGATION_KEYS = [
   "default",
@@ -35,9 +38,42 @@ export const MENU_NAVIGATION_KEYS = [
   "bonus",
   "others",
   "logout",
+  "faq",
+  "terms",
+  "policy",
+  "admin",
 ] as const;
 
-export const MENU_NAVIGATION: MenuNavigationType = [
+export const OTHERS_NAVIGATION = [
+  {
+    id: "faq",
+    title: "FAQ",
+
+    hasChevron: false,
+  },
+  {
+    id: "terms",
+    title: "利用規約",
+
+    hasChevron: false,
+  },
+  {
+    id: "policy",
+    title: "プライバシーポリシー",
+
+    hasChevron: false,
+  },
+  {
+    id: "admin",
+    title: "Admin",
+
+    hasChevron: false,
+  },
+] as const satisfies MenuNavigationItemProps[];
+
+export const MENU_NAVIGATION = ({
+  onClick = () => {},
+}: Pick<MenuListProps, "onClick">): MenuNavigationType => [
   {
     groupId: "default",
     items: [],
@@ -53,6 +89,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         title: "フォルダ",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("folder"),
       },
       {
         id: "cvtag",
@@ -62,6 +99,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         title: "一括タグ",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("cvtag"),
       },
       {
         id: "replacement",
@@ -71,6 +109,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         title: "マジック置換",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("replacement"),
       },
       {
         id: "media",
@@ -80,6 +119,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         title: "メディア",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("media"),
       },
       {
         id: "inspection",
@@ -89,6 +129,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         title: "審査",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("inspection"),
       },
       {
         id: "form",
@@ -98,6 +139,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         title: "フォーム",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("form"),
       },
     ],
   },
@@ -110,6 +152,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         description: "広告管理画面の数値を取得できます",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("ad"),
       },
       {
         id: "cv-measurement",
@@ -117,6 +160,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         description: "ECカートやCRMのCV数を表示できます",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("cv-measurement"),
       },
     ],
   },
@@ -129,6 +173,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         description: "作業するチームを選択できます。",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("team"),
       },
       {
         id: "role",
@@ -136,6 +181,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         description: "チームメンバーを管理できます",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("role"),
       },
       {
         id: "user-settings",
@@ -143,6 +189,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         description: "お客様自身の情報を確認・変更できます",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("user-settings"),
       },
       {
         id: "plans",
@@ -150,6 +197,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         description: "ご利用中のプラン料金を確認できます",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("plans"),
       },
       {
         id: "payments",
@@ -157,6 +205,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         description: "お支払い情報を確認・変更",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("payments"),
       },
       {
         id: "bonus",
@@ -164,6 +213,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
         description: "ご紹介キャッシュバック等の特典があります",
         href: "",
         hasChevron: false,
+        onClick: () => onClick("bonus"),
       },
       {
         id: "others",
@@ -173,7 +223,7 @@ export const MENU_NAVIGATION: MenuNavigationType = [
           <div className="mt-4 flex flex-col gap-y-2 pl-4">
             {OTHERS_NAVIGATION.map((nav) => (
               <ListItem
-                {...nav}
+                {...{ ...nav, onClick: () => onClick(nav.id) }}
                 key={nav.id}
               />
             ))}

--- a/src/components/molecules/MenuList/type.ts
+++ b/src/components/molecules/MenuList/type.ts
@@ -9,6 +9,7 @@ export type MenuListTypeKey = "beyond" | "connection" | "account" | "default";
 export type MenuListProps = {
   navigationType: MenuListTypeKey;
   onMouseEnter: (id: MenuKindKey) => void;
+  onClick?: (id: MenuKindKey) => void;
 };
 
 export type MenuNavigationItemProps = Omit<ListItemProps, "id"> & { id: MenuKindKey };

--- a/src/components/organisms/GlobalNavigation/GlobalNavigation.stories.tsx
+++ b/src/components/organisms/GlobalNavigation/GlobalNavigation.stories.tsx
@@ -22,6 +22,24 @@ export default {
     selectedId: {
       type: "string",
     },
+    userId: {
+      type: "string",
+    },
+    userImage: {
+      type: "string",
+    },
+    userName: {
+      type: "string",
+    },
+    teamName: {
+      type: "string",
+    },
+  },
+  args: {
+    userId: "1",
+    userName: "田中太郎",
+    userImage: "https://via.placeholder.com/100",
+    teamName: "Squad Beyond",
   },
 } satisfies Meta<typeof GlobalNavigation>;
 

--- a/src/components/organisms/GlobalNavigation/GlobalNavigation.stories.tsx
+++ b/src/components/organisms/GlobalNavigation/GlobalNavigation.stories.tsx
@@ -16,6 +16,9 @@ export default {
     onChangeSelectedId: {
       type: "function",
     },
+    onClickAccountMenu: {
+      type: "function",
+    },
     selectedId: {
       type: "string",
     },

--- a/src/components/organisms/GlobalNavigation/GlobalNavigation.tsx
+++ b/src/components/organisms/GlobalNavigation/GlobalNavigation.tsx
@@ -15,6 +15,10 @@ export const GlobalNavigation = ({
   groups,
   hasOnlyLogo = false,
   onClickAccountMenu,
+  userId,
+  userName,
+  userImage,
+  teamName,
 }: GlobalNavigationProps) => {
   const { isDesktop, isMobile } = useScreenSize();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -54,9 +58,10 @@ export const GlobalNavigation = ({
             ref={(el) => noCloseRefs.current.push(el)}
           >
             <GlobalAccount
-              userId="1"
-              userName="田中 太郎"
-              teamName="Squad beyondチーム"
+              userId={userId}
+              userImage={userImage}
+              userName={userName}
+              teamName={teamName}
               onClick={() => toggleDialog("account")}
             />
             <RichMenu

--- a/src/components/organisms/GlobalNavigation/GlobalNavigation.tsx
+++ b/src/components/organisms/GlobalNavigation/GlobalNavigation.tsx
@@ -10,7 +10,12 @@ import { NavigationListUI } from "./components/NavigationListUI";
 import { useRichMenuDialog } from "./hooks";
 import type { GlobalNavigationProps } from "./type";
 
-export const GlobalNavigation = ({ items, groups, hasOnlyLogo = false }: GlobalNavigationProps) => {
+export const GlobalNavigation = ({
+  items,
+  groups,
+  hasOnlyLogo = false,
+  onClickAccountMenu,
+}: GlobalNavigationProps) => {
   const { isDesktop, isMobile } = useScreenSize();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
@@ -59,6 +64,7 @@ export const GlobalNavigation = ({ items, groups, hasOnlyLogo = false }: GlobalN
               navigationType="account"
               absolute
               anchor="right"
+              onClick={onClickAccountMenu}
             />
           </div>
         )}

--- a/src/components/organisms/GlobalNavigation/type.ts
+++ b/src/components/organisms/GlobalNavigation/type.ts
@@ -1,4 +1,5 @@
 import { ListItemProps } from "@atoms/ListItem/type";
+import { MenuKindKey } from "@components/molecules";
 import { RichMenuProps } from "../RichMenu/type";
 import { MergeType } from "@/src/utils/type-utils";
 
@@ -8,4 +9,5 @@ export type GlobalNavigationProps = {
   selectedId: string;
   hasOnlyLogo?: boolean;
   onChangeSelectedId?: (id: string) => void;
+  onClickAccountMenu?: (key: MenuKindKey) => void;
 };

--- a/src/components/organisms/GlobalNavigation/type.ts
+++ b/src/components/organisms/GlobalNavigation/type.ts
@@ -1,5 +1,6 @@
 import { ListItemProps } from "@atoms/ListItem/type";
 import { MenuKindKey } from "@components/molecules";
+import { GlobalAccountProps } from "../GlobalAccount/type";
 import { RichMenuProps } from "../RichMenu/type";
 import { MergeType } from "@/src/utils/type-utils";
 
@@ -10,4 +11,4 @@ export type GlobalNavigationProps = {
   hasOnlyLogo?: boolean;
   onChangeSelectedId?: (id: string) => void;
   onClickAccountMenu?: (key: MenuKindKey) => void;
-};
+} & Pick<GlobalAccountProps, "teamName" | "userId" | "userImage" | "userName">;

--- a/src/components/organisms/RichMenu/RIchMenu.tsx
+++ b/src/components/organisms/RichMenu/RIchMenu.tsx
@@ -13,6 +13,7 @@ export const RichMenu = ({
   navigationType,
   anchor = "left",
   groups,
+  onClick,
 }: RichMenuProps) => {
   const { height: windowHeight } = useScreenSize();
   const { rectState, clientRectRef } = useClientRect({ enabled: isOpen });
@@ -36,6 +37,7 @@ export const RichMenu = ({
       <MenuList
         navigationType={navigationType}
         onMouseEnter={(id) => setHoveredMenuId(id)}
+        onClick={onClick}
       />
       <RichMenuContents
         menuId={hoveredMenuId}

--- a/src/components/organisms/RichMenu/type.ts
+++ b/src/components/organisms/RichMenu/type.ts
@@ -1,4 +1,4 @@
-import type { MenuListTypeKey } from "@components/molecules/MenuList";
+import type { MenuKindKey, MenuListTypeKey } from "@components/molecules/MenuList";
 import { RichMenuListProps } from "@components/molecules/RichMenuList/type";
 
 export type RichMenuProps = {
@@ -8,4 +8,5 @@ export type RichMenuProps = {
   absolute?: boolean;
   anchor?: "right" | "left";
   groups?: RichMenuListProps["groups"];
+  onClick?: (key: MenuKindKey) => void;
 };


### PR DESCRIPTION
## 概要 / Overview

<!--
実装内容のSummaryを記述する
Describe the summary of the implementation
-->
GlobalNavigation: GlobalAccount 操作時の処理を追加できるよう修正

### package.jsonのversion

- [ ] 上げました

### Figmaのリンク / Figma Link

<!--
Figmaの該当箇所のリンクを貼る
Please attach the relevant link from Figma.
-->

### Jira のチケット / Jira Ticket
https://siva-inc.atlassian.net/browse/TEAMA-235
https://siva-inc.atlassian.net/browse/TEAMA-236

<!--
Jiraのチケットのリンクを貼る
Link to Jira ticket
 -->

## 変更内容 / Changes
GlobalNavigation: GlobalAccount 操作時の処理を追加できるよう修正

<!--
  変更内容を記述する
  Describe your changes here
-->

## その他 / Other

<!--
  その他困ったこととか伝えたいことを何でも
  Anything else you want to share?
 -->
スピード重視で結構無理矢理な実装になっています。。
リストのコンテンツを dashboard 側に寄せるなどリファクタが必要そうな場合は後々対応します