### PR TITLE
ListItemのisSelect時の色修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2024-03-22-01",
+  "version": "0.10.2024-04-12-01",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/ListItem/const.ts
+++ b/src/components/atoms/ListItem/const.ts
@@ -24,7 +24,7 @@ export const LIST_ITEM_CONTAINER_CLASS_NAME = tv({
       normal: clsx(
         "hover:enabled:bg-gray-extraLight",
         "focus-visible:ring-primary-600",
-        "[&:not(:focus-visible)]:focus:bg-primary-50",
+        "[&:not(:focus-visible)]:focus:bg-gray-extraLight",
       ),
       red: clsx("hover:enabled:bg-red-light", "focus-visible:ring-red", "focus:bg-red-light"),
     },
@@ -42,7 +42,7 @@ export const LIST_ITEM_CONTAINER_CLASS_NAME = tv({
     {
       theme: "normal",
       isSelected: true,
-      class: "bg-primary-50",
+      class: "bg-gray-extraLight",
     },
     {
       theme: "normal",


### PR DESCRIPTION
## 概要 / Overview
`ListItem`コンポーネントの`isSelect`時の背景色を`bg-primary-50`から`bg-gray-extraLight`に変更

## スクリーンショット
| 変更前 | 変更後 |
| --- | --- |
| <img width="368" alt="old" src="https://github.com/siva-squad/squad-ui/assets/61968429/91de825a-ca08-48a1-81e6-b9906c3004ab"> | <img width="368" alt="new" src="https://github.com/siva-squad/squad-ui/assets/61968429/acd41f55-d56d-4600-9850-62e76c0c4688"> | 

## 対応背景
https://github.com/siva-squad/squadbeyond-frontend/pull/455 <- こちらのタスク内で色変更の要望があったため

## 小疑問
選択時は薄い青の方がアクティブ感がわかりやすい気がするんですが、
hover時と同じでグレーにする事になった背景が少し気になります 🧐