### PR TITLE
feat(ListItem):💄ホバー時のスタイルが重なって表示されてしまうため修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siva-squad-development/squad-ui",
   "private": false,
-  "version": "0.10.2024-04-12-01",
+  "version": "0.10.2024-04-15-01",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/ListItem/const.ts
+++ b/src/components/atoms/ListItem/const.ts
@@ -48,7 +48,6 @@ export const LIST_ITEM_CONTAINER_CLASS_NAME = tv({
       theme: "normal",
       isAnchor: true,
       isDisabled: false,
-      class: "hover:bg-gray-extraLight",
     },
     {
       theme: "red",


### PR DESCRIPTION
## 概要 / Overview

squadbeyond-frontendで使う際に背景色が重なって濃く表示されてしまう(以下の動画参照)ので修正しました


https://github.com/siva-squad/squad-ui/assets/19528768/f86f75b8-aae5-46c4-9399-c43726619c8b

