### PR TITLE
ListItemのラベル部分が親コンポーネントのwidthを引き継いで、truncateが適切に機能するよう修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@siva-squad-development/squad-ui",
-  "private": false,
-  "version": "0.10.2024-04-17-01",
+  "version": "0.10.2024-04-17-02",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/ListItem/ListItem.tsx
+++ b/src/components/atoms/ListItem/ListItem.tsx
@@ -64,7 +64,7 @@ export const ListItem = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, 
             {iconUI}
           </span>
         )}
-        <span className="flex flex-1 flex-col items-start">
+        <span className="flex flex-1 flex-col items-start w-full">
           <span className={LIST_ITEM_TEXT_CLASS_NAME({ size, theme, isDisabled })}>{title}</span>
           {description && size === "large" && (
             <span className={LIST_ITEM_DESCRIPTION_CLASS_NAME({ isSelected, theme, isDisabled })}>

--- a/src/components/atoms/ListItem/const.ts
+++ b/src/components/atoms/ListItem/const.ts
@@ -59,7 +59,7 @@ export const LIST_ITEM_CONTAINER_CLASS_NAME = tv({
 });
 
 export const LIST_ITEM_TEXT_CLASS_NAME = tv({
-  base: clsx("truncate w-full text-sm font-medium", "group-disabled:opacity-20"),
+  base: clsx("truncate w-full text-left text-sm font-medium", "group-disabled:opacity-20"),
   variants: {
     isDisabled: {
       true: "opacity-20",

--- a/src/components/atoms/ListItem/const.ts
+++ b/src/components/atoms/ListItem/const.ts
@@ -59,7 +59,7 @@ export const LIST_ITEM_CONTAINER_CLASS_NAME = tv({
 });
 
 export const LIST_ITEM_TEXT_CLASS_NAME = tv({
-  base: clsx("truncate text-sm font-medium", "group-disabled:opacity-20"),
+  base: clsx("truncate w-full text-sm font-medium", "group-disabled:opacity-20"),
   variants: {
     isDisabled: {
       true: "opacity-20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13513,21 +13513,21 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
   version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=1f5320"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
+  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=1f5320"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
+  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 概要 / Overview

<!--
実装内容のSummaryを記述する
Describe the summary of the implementation
-->
- タイトル通り
- 経緯
  - [呼び出し元](https://github.com/siva-squad/squadbeyond-frontend/blob/89a223b528c0fdfba314203d310e8731382d6016/src/components/layouts/FolderLayout/FolderListSidebar/FolderListSidebar.tsx#L43)側でarbitrary variantsを使用してwidth: 100%を適用しようとする実装をされていたが、実際には子コンポーネントに適用されていなかった
  - そもそもui側のclassNameにtruncateが含まれている以上、w-fullは必須
  - よってui側で適用するよう修正
### package.jsonのversion

- [x] 上げました

### Figmaのリンク / Figma Link

<!--
Figmaの該当箇所のリンクを貼る
Please attach the relevant link from Figma.
-->

### Jira のチケット / Jira Ticket
- https://siva-inc.atlassian.net/browse/TEAMA-389
<!--
Jiraのチケットのリンクを貼る
Link to Jira ticket
 -->

## 変更内容 / Changes

<!--
  変更内容を記述する
  Describe your changes here
-->

## その他 / Other

<!--
  その他困ったこととか伝えたいことを何でも
  Anything else you want to share?
 -->
