### PR TITLE
Add readOnly to type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siva-squad-development/squad-ui",
-  "version": "0.10.2024-04-18-01",
+  "version": "0.10.2024-04-19-01",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/Input/InputText/type.ts
+++ b/src/components/atoms/Input/InputText/type.ts
@@ -16,6 +16,7 @@ export type InputTextProps = InputStyleProps &
     | "defaultValue"
     | "value"
     | "onChange"
+    | "readOnly"
   > & {
     showSuccess?: boolean;
     type?: "email" | "password" | "search" | "text";


### PR DESCRIPTION
## 概要 / Overview

- Sometimes the attribute `readOnly` is needed when using a text input
- テキスト入力を使用する場合、`readOnly`属性が必要になることがある。