### PR TITLE
InputElementのエラー表示領域固定切替対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siva-squad-development/squad-ui",
-  "version": "0.10.2024-04-19-02",
+  "version": "0.10.2024-04-25-01",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siva-squad-development/squad-ui",
-  "version": "0.10.2024-04-25-01",
+  "version": "0.10.2024-04-25-02",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siva-squad-development/squad-ui",
-  "version": "0.10.2024-04-25-02",
+  "version": "0.10.2024-04-25-01",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/molecules/InputElement/InputElement.stories.tsx
+++ b/src/components/molecules/InputElement/InputElement.stories.tsx
@@ -39,6 +39,9 @@ export default {
     render: {
       type: "function",
     },
+    occupyErrorArea: {
+      type: "boolean",
+    },
   },
 } satisfies Meta<typeof InputElement>;
 

--- a/src/components/molecules/InputElement/InputElement.stories.tsx
+++ b/src/components/molecules/InputElement/InputElement.stories.tsx
@@ -67,6 +67,69 @@ export const Default: StoryObj<typeof InputElement> = {
   ],
 };
 
+export const OccupiedErrorArea = () => {
+  return (
+    <div>
+      <h2 className="mb-2">Occupied</h2>
+      <section className="flex items-end gap-x-2">
+        <InputElement
+          htmlFor="testId-1"
+          label="タイトル-1"
+          isRequired
+          errorText="text"
+          occupyErrorArea
+          render={({ htmlFor }) => (
+            <InputText
+              placeholder="プレイスホルダー"
+              id={htmlFor}
+            />
+          )}
+        />
+        <InputElement
+          htmlFor="testId-2"
+          label=""
+          isRequired
+          showRequired={false}
+          occupyErrorArea
+          render={({ htmlFor }) => (
+            <InputText
+              placeholder="プレイスホルダー"
+              id={htmlFor}
+            />
+          )}
+        />
+      </section>
+      <h2 className="mb-2 mt-6">Unoccupied</h2>
+      <section className="flex items-end gap-x-2">
+        <InputElement
+          htmlFor="testId-1"
+          label="タイトル-1"
+          isRequired
+          errorText="text"
+          render={({ htmlFor }) => (
+            <InputText
+              placeholder="プレイスホルダー"
+              id={htmlFor}
+            />
+          )}
+        />
+        <InputElement
+          htmlFor="testId-2"
+          label=""
+          isRequired
+          showRequired={false}
+          render={({ htmlFor }) => (
+            <InputText
+              placeholder="プレイスホルダー"
+              id={htmlFor}
+            />
+          )}
+        />
+      </section>
+    </div>
+  );
+};
+
 export const WithHtmlForDescription: StoryObj<typeof InputElement> = {
   args: {
     htmlFor: "testId",

--- a/src/components/molecules/InputElement/InputElement.tsx
+++ b/src/components/molecules/InputElement/InputElement.tsx
@@ -13,6 +13,7 @@ export const InputElement = ({
   isRequired = true,
   optionalText,
   requiredText,
+  occupyErrorArea = false,
 }: InputElementProps) => {
   const visibleLabel = showLabel ? "text-sm font-medium leading-tight" : "sr-only";
   const visibleGap = showLabel && showRequired && "gap-x-2";
@@ -44,7 +45,12 @@ export const InputElement = ({
           description
         ))}
       {elementUI}
-      {!!errorText && <p className="text-xs leading-normal text-red">{errorText}</p>}
+      {errorText ? (
+        <p className="text-xs leading-normal text-red">{errorText}</p>
+      ) : occupyErrorArea ? (
+        // NOTE: チラつき対策でエラーテキストの表示領域確保
+        <span className="invisible text-xs leading-normal">-</span>
+      ) : null}
     </div>
   );
 };

--- a/src/components/molecules/InputElement/type.ts
+++ b/src/components/molecules/InputElement/type.ts
@@ -12,6 +12,7 @@ export type InputElementProps = {
   showRequired?: boolean;
   showLabel?: boolean;
   children?: ReactElement;
+  occupyErrorArea?: boolean;
   render: (form: FormType) => ReactElement;
 } & FormType &
   RequiredBadgeProps;


### PR DESCRIPTION
## 概要 / Overview

現状InputElementのエラー領域はエラー時にのみ出現し、
横並びのアイテム同士が揃わなくなる為表示領域の固定切り替えを追加。

<img width="517" alt="スクリーンショット 2024-04-25 9 44 00" src="https://github.com/siva-squad/squad-ui/assets/61968429/c25a80fe-7be4-4fab-92e5-2be77abe1ed2">


こちらのPRで使用
https://github.com/siva-squad/squadbeyond-frontend/pull/561

<img width="554" alt="スクリーンショット 2024-04-25 9 31 25" src="https://github.com/siva-squad/squad-ui/assets/61968429/9e18717c-c4be-4a78-935c-5f7cd29f9c7e">