### PR TITLE
feat(Selector):✨Selectorでテキストを入力して検索可能にした

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siva-squad-development/squad-ui",
-  "version": "0.10.2024-04-25-01",
+  "version": "0.10.2024-04-25-02",
   "main": "./dist/squad-ui.umd.js",
   "module": "./dist/squad-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/atoms/Selector/ForSearch/ForSearch.tsx
+++ b/src/components/atoms/Selector/ForSearch/ForSearch.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
+import clsx from "clsx";
+import {
+  ICON_CLASS_NAME,
+  LABEL_CLASS_NAME,
+  SELECTOR_BUTTON_CLASS_NAME,
+  SELECTOR_WRAPPER_CLASS_NAME,
+} from "../const";
+import { useOutsideClick } from "../hooks";
+import { SelectorList } from "../SelectorList";
+
+import type { BaseOptionValue, OptionType, SelectorProps } from "../type";
+
+export const ForSearch = <OptionValue extends BaseOptionValue>({
+  size,
+  options,
+  value,
+  placeholder,
+  disabled,
+  onSelect,
+  listHeight,
+  defaultValue,
+}: SelectorProps<OptionValue>) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const activeLabel = useMemo(
+    () =>
+      options.find((option) => option.value === value)?.label ??
+      options.find((option) => option.value === defaultValue)?.label ??
+      placeholder,
+    [options, value, placeholder, defaultValue],
+  );
+
+  useOutsideClick(wrapperRef, () => setIsOpen(false));
+
+  const handleButtonClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setIsOpen((prevIsOpen) => !prevIsOpen);
+  };
+
+  const onClick = (option: OptionType<OptionValue>) => {
+    setKeyword(option.label);
+    onSelect(option.value);
+    setIsOpen(false);
+  };
+  const [keyword, setKeyword] = useState<string>(activeLabel || placeholder);
+  const [keywordForSearch, setKeywordForSearch] = useState<string>("");
+  const search = (_keyword: string) => options.filter((option) => option.label.includes(_keyword));
+
+  useEffect(() => {
+    if (options.find((option) => option.label === keyword)) return;
+    setKeyword(activeLabel);
+  }, [isOpen]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={SELECTOR_WRAPPER_CLASS_NAME({ size })}
+    >
+      <div
+        className={SELECTOR_BUTTON_CLASS_NAME({ size, disabled })}
+        aria-disabled={disabled ? "true" : "false"}
+      >
+        <input
+          type="text"
+          onFocus={() => {
+            setKeywordForSearch("");
+            setIsOpen(true);
+          }}
+          onChange={(e) => {
+            setKeyword(e.target.value);
+            setKeywordForSearch(e.target.value);
+          }}
+          value={keyword}
+          className={clsx(
+            LABEL_CLASS_NAME({ size, disabled, isActive: !!activeLabel }),
+            "w-full text-start",
+            "focus:outline-none",
+          )}
+        />
+        <button onClick={handleButtonClick}>
+          <ChevronDownIcon
+            className={clsx(
+              ICON_CLASS_NAME({ disabled }),
+              "transition-all duration-200",
+              isOpen && "rotate-180",
+            )}
+          />
+        </button>
+      </div>
+      {isOpen && (
+        <SelectorList
+          listHeight={listHeight}
+          options={search(keywordForSearch)}
+          value={value}
+          onClick={onClick}
+          rect={wrapperRef.current?.getBoundingClientRect()}
+          defaultValue={defaultValue}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/components/atoms/Selector/ForSearch/index.ts
+++ b/src/components/atoms/Selector/ForSearch/index.ts
@@ -1,0 +1,1 @@
+export * from "./ForSearch";

--- a/src/components/atoms/Selector/Selector.stories.tsx
+++ b/src/components/atoms/Selector/Selector.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { StoryObj, Meta } from "@storybook/react";
 import { Selector } from "./Selector";
 
@@ -31,19 +32,11 @@ export const Groups = () => {
       value: "option2",
     },
   ];
+  const [value, setValue] = useState("option1");
   return (
     <div className="flex flex-col gap-y-20">
       <Selector
-        options={[
-          {
-            label: "オプション1",
-            value: "option1",
-          },
-          {
-            label: "オプション2",
-            value: "option2",
-          },
-        ]}
+        options={options}
         value={"option1"}
         placeholder="選択肢が入ります"
         size="normal"
@@ -51,11 +44,13 @@ export const Groups = () => {
         onSelect={() => {}}
       />
       <Selector
+        enableSearch
         options={options}
+        value={value}
         placeholder="選択肢が入ります"
         size="normal"
         disabled={false}
-        onSelect={() => {}}
+        onSelect={(v) => setValue(v)}
       />
     </div>
   );

--- a/src/components/atoms/Selector/Selector.stories.tsx
+++ b/src/components/atoms/Selector/Selector.stories.tsx
@@ -32,25 +32,26 @@ export const Groups = () => {
       value: "option2",
     },
   ];
-  const [value, setValue] = useState("option1");
+  const [value1, setValue1] = useState("option1");
+  const [value2, setValue2] = useState("option1");
   return (
     <div className="flex flex-col gap-y-20">
       <Selector
         options={options}
-        value={"option1"}
+        value={value1}
         placeholder="選択肢が入ります"
         size="normal"
         disabled={false}
-        onSelect={() => {}}
+        onSelect={setValue1}
       />
       <Selector
         enableSearch
         options={options}
-        value={value}
+        value={value2}
         placeholder="選択肢が入ります"
         size="normal"
         disabled={false}
-        onSelect={(v) => setValue(v)}
+        onSelect={setValue2}
       />
     </div>
   );

--- a/src/components/atoms/Selector/Selector.tsx
+++ b/src/components/atoms/Selector/Selector.tsx
@@ -6,6 +6,7 @@ import {
   SELECTOR_BUTTON_CLASS_NAME,
   SELECTOR_WRAPPER_CLASS_NAME,
 } from "./const";
+import { ForSearch } from "./ForSearch";
 import { useOutsideClick } from "./hooks";
 import { SelectorList } from "./SelectorList";
 
@@ -20,6 +21,7 @@ export const Selector = <OptionValue extends BaseOptionValue>({
   onSelect,
   listHeight,
   defaultValue,
+  enableSearch = false,
 }: SelectorProps<OptionValue>) => {
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -32,6 +34,13 @@ export const Selector = <OptionValue extends BaseOptionValue>({
   );
 
   useOutsideClick(wrapperRef, () => setIsOpen(false));
+
+  if (enableSearch)
+    return (
+      <ForSearch
+        {...{ size, options, value, placeholder, disabled, onSelect, listHeight, defaultValue }}
+      />
+    );
 
   const handleButtonClick = (event: React.MouseEvent) => {
     event.stopPropagation();

--- a/src/components/atoms/Selector/const.ts
+++ b/src/components/atoms/Selector/const.ts
@@ -36,7 +36,7 @@ export const SELECTOR_BUTTON_CLASS_NAME = tv({
 });
 
 export const LABEL_CLASS_NAME = tv({
-  base: "text-center font-normal leading-none truncate",
+  base: "truncate text-center font-normal leading-none",
   variants: {
     size: {
       small: "text-xs",

--- a/src/components/atoms/Selector/type.ts
+++ b/src/components/atoms/Selector/type.ts
@@ -17,4 +17,5 @@ export type SelectorProps<OptionValue extends BaseOptionValue> = {
   disabled?: boolean;
   listHeight?: number;
   onSelect: (value: OptionValue) => void;
+  enableSearch?: boolean;
 };


### PR DESCRIPTION
## 概要

Selectorにテキストを直接入力して選択肢の中から検索したい要件があったため対応しました

https://github.com/siva-squad/squad-ui/assets/19528768/343090ea-887f-446e-8721-05edb83a9e52

## 変更内容

Selector以下に`ForSearch`コンポーネントを追加しました
`enableSearch`の切り替えで`Selector`, `ForSearch`が切り替わるようになっています

## その他

スピード優先でかなり雑な実装になっています